### PR TITLE
prevents action plan bug from old date format

### DIFF
--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -308,7 +308,9 @@ class ActionPlanForm extends React.Component<Props, State> {
       this.setState({
         actionPlanExists: true,
         goal: actionPlanData.goal,
-        goalTimeline: actionPlanData.goalTimeline ? actionPlanData.goalTimeline.toDate() : new Date(),
+        goalTimeline: (actionPlanData.goalTimeline && (typeof actionPlanData.goalTimeline !== 'string')) ?
+          actionPlanData.goalTimeline.toDate() :
+          new Date(),
         benefit: actionPlanData.benefit,
         date: newDate
       });


### PR DESCRIPTION
prior to adding date picker, the Achieve By (goalTimeline) section in the action plan accepted and saved a string from the user, but if they had added a string in this section, none of the action plan data would render. this checks if the field exists and if it is not a string (meaning it is firebase.firestore.Timestamp type), then it converts it to a Date for the date picker, otherwise it uses today's date