### PR TITLE
error with retrieving action steps with old date format

### DIFF
--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -331,7 +331,9 @@ class ActionPlanForm extends React.Component<Props, State> {
             step: value.step,
             materials: value.materials,
             person: value.person,
-            timeline: value.timeline ? value.timeline.toDate() : new Date()
+            timeline: (value.timeline && (typeof value.timeline !== 'string')) ?
+              value.timeline.toDate() :
+              new Date(),
           };
         })
       }).then(() => {


### PR DESCRIPTION
prevents same bug that occurred with the action plan date, which also occurs for all action steps...old version saved as string in Firestore prevents action steps from showing up