### PR TITLE
Change order

### DIFF
--- a/src/components/LiteracyComponents/ActivitySettingModal.tsx
+++ b/src/components/LiteracyComponents/ActivitySettingModal.tsx
@@ -100,7 +100,7 @@ function ActivitySettingModal(props: Props): React.ReactElement {
             </Grid>
             <Grid item style={{width: '100%', paddingTop: '0.5em'}}>
               <Typography style={{fontFamily: 'Arimo'}}>
-                Select {checklistType === 'ReadingTeacher' ? 'or create ' : ' '}a label describing the type of activity that was happening for most of {checklistType === 'ReadingTeacher' ? 'text read during this observation' : 'this observation'}:
+                Select a label that best describes the type of {checklistType === 'ReadingTeacher' ? 'text read during this observation' : 'this observation'}:
               </Typography>
             </Grid>
             <Grid item>

--- a/src/components/LiteracyComponents/ResultsComponents/LiteracyDetailsWritingChart.tsx
+++ b/src/components/LiteracyComponents/ResultsComponents/LiteracyDetailsWritingChart.tsx
@@ -52,9 +52,9 @@ class LiteracyDetailsWritingChart extends React.Component<Props, {}> {
     const teacherData = {  
       labels: [
         ["Talks to children about the content", "or meaning of the writing/drawing"],
+        ["Invites children to write", "part of a message"],
         ["Writes a meaningful message", "in front of children"],
         ["Demonstrates and talks about", "print processes"],
-        ["Invites children to write", "part of a message"],
         ["Invites children to write", "their name"],
         ["Responds positively to all", "writing forms"],
         ["Supports children's", "inventive spelling"],


### PR DESCRIPTION
KN: Still says "Select or create a label...." Complete observation pop-up should say: “Select a label that best describes the type of text read during this observation:”
KN: still innacurate: The Teacher Behaviors results (details chart) don't match the data collected. For example, if I select "invites children to write part of a message" it shows up in the details chart as "writes a meaningful message in front of children." Please check that the links between all the items and details chart are correct.