### PR TITLE
Fix FAQ section in level of instruction

### DIFF
--- a/src/components/LevelOfInstructionComponents/ResultsComponents/LevelOfInstructionCoachingQuestions.tsx
+++ b/src/components/LevelOfInstructionComponents/ResultsComponents/LevelOfInstructionCoachingQuestions.tsx
@@ -89,10 +89,9 @@ class LevelOfInstructionCoachingQuestions extends React.Component<
         this.setState({
             faq: getFaqSection({
                 questions: [
-                    ...Constants.CoachingQuestions.AC.Associative,
-                    ...Constants.CoachingQuestions.AC.Cooperative,
-                    ...Constants.CoachingQuestions.AC.TeacherParticipation,
-                    ...Constants.CoachingQuestions.AC.TeacherSupport,
+                    ...Constants.CoachingQuestions.Instruction.highLevelQuestions,
+                    ...Constants.CoachingQuestions.Instruction.lowLevel,
+                    ...Constants.CoachingQuestions.Instruction.highLevelInstruction,
                 ],
                 user: await this.context.getUserInformation(),
             }),


### PR DESCRIPTION
Level of Instruction favorite buttons are visible but do not show up in FAQs when selected.