### PR TITLE
Change width of block in coaching questions

### DIFF
--- a/src/components/MathInstructionComponents/ResultsComponents/MathCoachingQuestions.tsx
+++ b/src/components/MathInstructionComponents/ResultsComponents/MathCoachingQuestions.tsx
@@ -211,7 +211,7 @@ class MathCoachingQuestions extends React.Component<Props, State> {
                                                     : 'default'
                                             }
                                             style={{
-                                                width: '9em',
+                                                width: '11vw',
                                                 height: '9em',
                                                 textTransform: 'none',
                                             }}


### PR DESCRIPTION
Math Instruction - when in iPad view, the FAQ button is beneath the other buttons- can we shrink the buttons and have one line

Should I also change sizing in all sections? 