### PR TITLE
Fix Student Engagement list delete button showing edit modal

### DIFF
--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { SyntheticEvent } from 'react'
 import { Theme } from '@material-ui/core/styles'
 import withStyles from '@material-ui/core/styles/withStyles'
 import Button from '@material-ui/core/Button'
@@ -469,7 +469,9 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
                         <Typography variant="subtitle2">
                           <IconButton
                             style={{ padding: '0' }}
-                            onClick={(): void => {
+                            onClick={(event: SyntheticEvent): void => {
+                              event.preventDefault()
+                              event.stopPropagation()
                               this.removeStudent(student)
                             }}
                           >


### PR DESCRIPTION
# Description

The delete button opened up the edit modal with removed child's name in it -
this fix prevents that from happening.
