### PR TITLE
Add modal for removing student

### DIFF
--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -519,12 +519,12 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
               </CardActionArea>
             </Card>
           ))}
-           {(this.state.showRemoveStudenModal ) ? 
-                <RemoveStudent 
+          <RemoveStudent 
                   removeStudent={this.removeStudent}
                   student={this.state.removeStudent}
                   closeModal={this.closeRemoveStudentModal}
-                  /> : null}
+                  isOpen={this.state.showRemoveStudenModal}
+                  />
           {this.state.status === Status.OBSERVATION && (
             <Grid
               container

--- a/src/components/StudentEngagementComponents/RemoveStudent.tsx
+++ b/src/components/StudentEngagementComponents/RemoveStudent.tsx
@@ -9,18 +9,19 @@ import Button from '@material-ui/core/Button'
 
 
 interface Props {
-  removeStudent(object),
+  removeStudent(object): void,
   student: object,
-  closeModal(),
+  closeModal(): void,
+  isOpen: boolean,
 }
 
 // eslint-disable-next-line require-jsdoc
 function RemoveStudent (props: Props) {
-  const { removeStudent, student, closeModal } = props;
+  const { removeStudent, student, closeModal, isOpen } = props;
 
   return (
            <Dialog
-          open={true}
+          open={isOpen}
           onClose={(): void => closeModal()}
           aria-labelledby="alert-dialog-title"
           aria-describedby="alert-dialog-description"


### PR DESCRIPTION
After clicking the delete button on a student card in the Student Engagement observation page

a modal with question "Are you sure you want to remove this student from the list?" (or something similar) and action buttons "Yes, remove student" & "No, keep student" should show up