### PR TITLE
Restore points in student engagement

### DIFF
--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -275,6 +275,16 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
     }
   }
 
+  // eslint-disable-next-line require-jsdoc
+  componentDidMount() {
+    this.props.students.forEach(({id}) => {
+      this.props.editStudent({
+        id,
+        count: 0,
+      })
+    })
+  }
+
   /**
     * internal update callback function
     * @param {Props} _previousProps


### PR DESCRIPTION
Currently the point count for each student on the Student Engagement observation page is kept between observations

 Before each new observation all the points should be set to 0