### PR TITLE
Fix add button in student engagement

### DIFF
--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -254,7 +254,7 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
   onStudentModalOpen = (student?: Student): void => {
     const { status } = this.state
 
-    if (status === Status.NAME_LIST) {
+    if (status === Status.NAME_LIST || !student) {
       this.setState({
         setOpen: true,
         studentTextFieldValue: student?.name ?? '',


### PR DESCRIPTION
During the Student Engagement observation there should be a possibility to add a new student


 
using the "+" button. However, it does not seem to perform any action.