### PR TITLE
Teacher dependent student engagement observation list

### DIFF
--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -400,7 +400,10 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
                 if (editedStudent) {
                   this.props.editStudent({ id: editedStudent.id, name })
                 } else {
-                  this.props.addStudent({ name, count: 0 })
+                  this.props.addStudent({
+                    student: { name, count: 0 },
+                    teacherId: this.props.teacherId
+                  })
                 }
 
                 this.handleClose()

--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -31,6 +31,7 @@ import {
   editStudent,
   removeStudent,
   resetStudents,
+  removeUnassignedStudents
 } from '../../state/actions/students'
 import type { Student } from '../../state/reducers/students-state'
 import type { RootState } from '../../state/store'
@@ -295,7 +296,8 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
   }
 
   // eslint-disable-next-line require-jsdoc
-  componentDidMount() {
+  componentDidMount(): void {
+    this.props.removeUnassignedStudents()
     this.props.students.forEach(({id}) => {
       this.props.editStudent({
         id,
@@ -596,6 +598,7 @@ const mapDispatch = {
   updateEngagementCount,
   addStudent,
   editStudent,
+  removeUnassignedStudents,
   removeStudent,
   resetStudents,
 }

--- a/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
+++ b/src/components/StudentEngagementComponents/CenterMenuStudentEngagement.tsx
@@ -586,9 +586,12 @@ class CenterMenuStudentEngagement extends React.Component<Props, State> {
   }
 }
 
-const mapState = (state: RootState) => ({
-  students: state.studentsState.students,
+const mapState = (state: RootState, ownProps: { teacherId: string }): { students: Student[] } => ({
+  students: state.studentsState.students.filter(
+    ({ teacherId }) => typeof teacherId === "undefined" || teacherId === ownProps.teacherId
+  ),
 })
+
 const mapDispatch = {
   updateEngagementCount,
   addStudent,

--- a/src/state/actions/students.ts
+++ b/src/state/actions/students.ts
@@ -13,12 +13,13 @@ export type StudentsActionType =
   | { type: typeof STUDENTS_REMOVE, student: Student }
   | { type: typeof RESET_STUDENTS }
 
-export const addStudent = (student: NewStudent): StudentsActionType => ({
+export const addStudent = ({ student, teacherId } : { student: NewStudent, teacherId: string }): StudentsActionType => ({
   type: STUDENTS_ADD,
   student: {
     ...student,
-    id: nanoid()
-  }
+    id: nanoid(),
+    teacherId
+  },
 });
 
 export const editStudent = (student: EditedStudent): StudentsActionType => ({

--- a/src/state/actions/students.ts
+++ b/src/state/actions/students.ts
@@ -2,6 +2,7 @@ export const STUDENTS_ADD = "add_student";
 export const STUDENTS_EDIT = "edit_student";
 export const STUDENTS_REMOVE = "remove_student";
 export const RESET_STUDENTS = "reset_students"
+export const REMOVE_UNASSIGNED_STUDENTS = "remove_unassigned_students";
 
 import { nanoid } from 'nanoid'
 
@@ -11,6 +12,7 @@ export type StudentsActionType =
   | { type: typeof STUDENTS_ADD, student: Student }
   | { type: typeof STUDENTS_EDIT, student: EditedStudent }
   | { type: typeof STUDENTS_REMOVE, student: Student }
+  | { type: typeof REMOVE_UNASSIGNED_STUDENTS }
   | { type: typeof RESET_STUDENTS }
 
 export const addStudent = ({ student, teacherId } : { student: NewStudent, teacherId: string }): StudentsActionType => ({
@@ -35,3 +37,7 @@ export const removeStudent = (student: Student): StudentsActionType => ({
 export const resetStudents = (): StudentsActionType => ({
   type: RESET_STUDENTS,
 });
+
+export const removeUnassignedStudents = (): StudentsActionType => ({
+  type: REMOVE_UNASSIGNED_STUDENTS,
+})

--- a/src/state/reducers/students-state.ts
+++ b/src/state/reducers/students-state.ts
@@ -10,6 +10,7 @@ export type Student = {
   count: number
   id: string
   name: string
+  teacherId?: string
 }
 
 export type NewStudent = Omit<Student, 'id'>

--- a/src/state/reducers/students-state.ts
+++ b/src/state/reducers/students-state.ts
@@ -2,6 +2,7 @@ import {
   STUDENTS_ADD,
   STUDENTS_EDIT,
   STUDENTS_REMOVE,
+  REMOVE_UNASSIGNED_STUDENTS,
   RESET_STUDENTS,
   StudentsActionType,
 } from '../actions/students'
@@ -60,6 +61,14 @@ export default (
         students: updatedStudents,
       }
     }
+
+    case REMOVE_UNASSIGNED_STUDENTS: {
+      return {
+        ...state,
+        students: state.students.filter(({ teacherId }) => Boolean(teacherId)),
+      }
+    }
+
     case RESET_STUDENTS: {
       return {
         ...state,


### PR DESCRIPTION
# Description

Change the Student Engagement observation student list to be based on the
selected teacher rather than being common for all of them.

# Note

Children in the current lists will still be common to all the teacher until
removed and readded - we can make it so the children without assigned teacher
are removed automatically from the list to avoid any confusion. Let me know what
you think about that @thompchr :smile:
