### PR TITLE
#498 prevent PDFs from downloading after being attached to messages

### DIFF
--- a/src/components/MessagingComponents/NewMessageView.tsx
+++ b/src/components/MessagingComponents/NewMessageView.tsx
@@ -828,7 +828,7 @@ function NewMessageView(props: NewMessageViewProps): React.ReactElement {
         heightLeft -= pageHeight;
       }
       // use this for downloading pdf
-      pdf.save("download.pdf");
+      // pdf.save("download.pdf");
       const blobPDF = new Blob([ pdf.output('blob') ], { type: 'application/pdf'});
       const reader = new FileReader();
       reader.readAsDataURL(blobPDF);


### PR DESCRIPTION
had a lot of trouble with the NewMessage component when using the webpack-dev-server. But no issues present when I worked with a build. Just a heads up for when it gets to staging to make sure it's working as intended.