### PR TITLE
#496 increase aspect ratio for engagement summary bar chart

### DIFF
--- a/src/components/StudentEngagementComponents/ResultsComponents/AvgBarSummary.tsx
+++ b/src/components/StudentEngagementComponents/ResultsComponents/AvgBarSummary.tsx
@@ -49,7 +49,7 @@ class AvgBarSummary extends React.Component<Props, {}> {
       <HorizontalBar
         data={avgEngagementData}
         width={650}
-        height={50}
+        height={160}
         options={{
           animation: {
             onComplete: function(): void {


### PR DESCRIPTION
Increased aspect ratio. Looks kinda big at 1920x1080, but much smaller than this and the elements begin overflowing (#496) at smaller screen sizes. I can finagle the numbers some more if need be.

![EngagementChart1](https://user-images.githubusercontent.com/57590037/155768098-efa64fd3-444f-4330-a4bc-6da07373508a.png)
