### PR TITLE
Enable Complete Observation on various pages

### DIFF
--- a/src/components/CentersComponents/CenterRatingChecklist.tsx
+++ b/src/components/CentersComponents/CenterRatingChecklist.tsx
@@ -494,7 +494,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
     if (this.state.final) {
       this.handleChecklists();
     }
-    
+
     this.handleTimeUpNotification();
   }
 
@@ -710,8 +710,6 @@ class CenterRatingChecklist extends React.Component<Props, State> {
                   <Dashboard
                     type={this.props.type}
                     infoDisplay={
-                      <>
-                      <div onClick={() => this.handleCompleteObservation()}>Sweet</div>
                       <Countdown
                         type={this.props.type}
                         time={this.state.time}
@@ -719,7 +717,6 @@ class CenterRatingChecklist extends React.Component<Props, State> {
 
                       />
 
-                      </>
                     }
                     infoPlacement="center"
                     completeObservation={true}

--- a/src/components/CentersComponents/CenterRatingChecklist.tsx
+++ b/src/components/CentersComponents/CenterRatingChecklist.tsx
@@ -202,6 +202,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
       clearInterval(this.timer);
       if (this.state.final) {
         this.handleChecklists();
+        this.handleTimeUpNotification();
       } else {
         this.handleTimeUpNotification();
       }
@@ -303,7 +304,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
   }
 
   /**
-   * 
+   *
    * @param {Array<number>} childChecked
    * @param {Array<number>} teacherChecked
    */
@@ -482,6 +483,21 @@ class CenterRatingChecklist extends React.Component<Props, State> {
     }
   }
 
+  /*
+   * We're reenabling the "Complete Observation" button
+   *
+   * This function will get passed to the Dashboard Component, which
+   *  will then pass it to the 'YesNoDialog'. So the button will run this
+   *  function instead of the usual function
+   */
+  handleCompleteObservation = (): void => {
+    if (this.state.final) {
+      this.handleChecklists();
+    }
+    
+    this.handleTimeUpNotification();
+  }
+
   static propTypes = {
     classes: PropTypes.object.isRequired,
     toggleScreen: PropTypes.func.isRequired,
@@ -594,7 +610,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
               If teachers or students leave or join while you are observing a center,
               make sure your final selection reflects the largest number of people
               that were present at any point during the 1 minute observation in that
-              center. 
+              center.
             </DialogContentText>
             <Grid
               container
@@ -639,7 +655,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
                           : this.props.type === 'SA' ? Sequential2
                           : AC2
                       }
-                      
+
                       alt="2+ children without teacher"
                     />
                   </Button>
@@ -694,18 +710,24 @@ class CenterRatingChecklist extends React.Component<Props, State> {
                   <Dashboard
                     type={this.props.type}
                     infoDisplay={
+                      <>
+                      <div onClick={() => this.handleCompleteObservation()}>Sweet</div>
                       <Countdown
-                        type={this.props.type} 
-                        time={this.state.time} 
-                        timerTime={60000}  
-                        
-                      />}
+                        type={this.props.type}
+                        time={this.state.time}
+                        timerTime={60000}
+
+                      />
+
+                      </>
+                    }
                     infoPlacement="center"
-                    completeObservation={false}
+                    completeObservation={true}
                     startTimer={this.startTimer}
                     stopTimer={this.stopTimer}
                     startTime={this.props.startTime}
                     forceComplete={this.state.canForceEndSession}
+                    completeCallBackFunctionOverride={() => this.handleCompleteObservation()}
                   />
                 </Grid>
               </Grid>
@@ -788,7 +810,7 @@ class CenterRatingChecklist extends React.Component<Props, State> {
                               : this.props.type === 'SA' ? Sequential2
                               : AC2
                           }
-                          
+
                           alt="2+ children without teacher"
                         />
                       </Button>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -374,7 +374,7 @@ class Dashboard extends React.Component<Props, State> {
           open={this.state.resultsDialog==="MI" && (this.state.displayResultsDialog || this.props.forceComplete)}
           history={this.props.history}
         />
-        <EngagementResultsDialog 
+        <EngagementResultsDialog
           open={this.state.resultsDialog==="SE" && (this.state.displayResultsDialog || this.props.forceComplete)}
           history={this.props.history}
         />
@@ -416,7 +416,7 @@ class Dashboard extends React.Component<Props, State> {
             <LevelOfInstructionHelp open={this.state.help} close={this.handleClickAwayHelp} />
           : this.typeString === "LC" ?
             <ListeningToChildrenHelp open={this.state.help} close={this.handleClickAwayHelp} />
-          : this.typeString === "LI" ? 
+          : this.typeString === "LI" ?
             <LiteracyInstructionHelp open={this.state.help} close={this.handleClickAwayHelp} type={this.props.checklistType} />
           : <div />
         ) : this.state.notes ? (
@@ -459,7 +459,7 @@ class Dashboard extends React.Component<Props, State> {
                     {this.props.teacherSelected.firstName} {this.props.teacherSelected.lastName}
                   </Typography>
                 </Grid>
-              </Grid> 
+              </Grid>
             </Grid>
             <Grid
               container
@@ -513,6 +513,7 @@ class Dashboard extends React.Component<Props, State> {
                           buttonColor={Constants.Colors[this.props.type]}
                           disabled={!this.props.completeObservation}
                           disabledOnClick={this.handleIncomplete}
+                          completeCallBackFunctionOverride={this.props.completeCallBackFunctionOverride}
                           disabledClass={classes.completeButton}
                           buttonMargin={10}
                           dialogTitle={

--- a/src/components/Shared/YesNoDialog.tsx
+++ b/src/components/Shared/YesNoDialog.tsx
@@ -142,7 +142,7 @@ class YesNoDialog extends React.Component<Props, State> {
           checklistType={this.props.literacy}
         /> : null}
         <Button
-          onClick={ disabled? this.props.disabledOnClick : this.handleClickOpen}
+          onClick={ this.props.completeCallBackFunctionOverride ? this.props.completeCallBackFunctionOverride : (disabled? this.props.disabledOnClick : this.handleClickOpen)}
           variant={disabled? 'outlined' : this.props.buttonVariant}
           color={this.props.buttonColor}
           style={disabled? {} : {


### PR DESCRIPTION
Fix for Enable Complete Observation #580 

Updated dashboard to allow the page to run custom functions when "Complete Observation" button is clicked