### PR TITLE
Bug/action plan

### DIFF
--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -2128,6 +2128,36 @@ class ActionPlanForm extends React.Component<Props, State> {
                 </Grid>
               </Grid>
             </Grid>
+            <Grid
+                container
+                direction="row"
+                justify="flex-end"
+                alignItems="stretch"
+                style={{ height: '100%', paddingTop: '0.8em',}}
+              >
+            <Grid
+                  item
+                  style={{
+                    width: '21%',
+                    // border: '2px solid #6f39c4',
+                    borderRadius: '0.5em',
+                    height: '100%',
+                    overflow: 'auto',
+                  }}
+                >
+                      <Grid
+                        container
+                        direction="row"
+                        justify="center"
+                        alignItems="center"
+                        style={{ width: '100%' }}
+                      >
+                        <Grid item> 
+                        <Button style={{ width: '100%' }} variant="contained">Send to Maintenance folder</Button>
+                  </Grid>
+                </Grid>
+                </Grid>
+                </Grid>
           </Grid>
         ) : (
           <div>

--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -1340,7 +1340,7 @@ class ActionPlanForm extends React.Component<Props, State> {
             <Grid
               item
               xs={12}
-              style={{ width: '100%', height: '38vh' }}
+              style={{ width: '100%', height: '38vh', border: '2px solid #0988ec', borderRadius: '0.5em', }}
             >
               <Grid
                 container
@@ -1352,8 +1352,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                   item
                   style={{
                     width: '48%',
-                    border: '2px solid #0988ec',
-                    borderRadius: '0.5em',
+                    // border: '2px solid #0988ec',
+                    // borderRadius: '0.5em',
                     height: '100%',
                     overflow: 'auto',
                   }}
@@ -1578,8 +1578,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                                 variant="standard"
                                 fullWidth
                                 multiline
-                                rowsMax={4}
-                                rows={4}
+                                rowsMax={2}
+                                rows={2}
                                 className={
                                   classes.textField
                                 }
@@ -1659,8 +1659,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                   item
                   style={{
                     width: '28%',
-                    border: '2px solid #ffd300',
-                    borderRadius: '0.5em',
+                    // border: '2px solid #ffd300',
+                    // borderRadius: '0.5em',
                     height: '100%',
                     overflow: 'auto',
                   }}
@@ -1853,9 +1853,9 @@ class ActionPlanForm extends React.Component<Props, State> {
                                   fullWidth
                                   multiline
                                   rowsMax={
-                                    4
+                                    2
                                   }
-                                  rows={4}
+                                  rows={2}
                                   className={
                                     classes.textField
                                   }
@@ -1895,8 +1895,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                   item
                   style={{
                     width: '21%',
-                    border: '2px solid #6f39c4',
-                    borderRadius: '0.5em',
+                    // borderLeft: '2px solid #6f39c4',
+                    // borderRadius: '0.5em',
                     height: '100%',
                     overflow: 'auto',
                   }}

--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
-import { TextField, Popover } from '@material-ui/core'
+import { TextField, Popover, Collapse } from '@material-ui/core'
 import Button from '@material-ui/core/Button'
 import AddCircleIcon from '@material-ui/icons/AddCircle'
 import InfoIcon from '@material-ui/icons/Info'
@@ -1336,74 +1336,33 @@ class ActionPlanForm extends React.Component<Props, State> {
                   </Grid>
                 </Grid>
               </Grid>
-            </Grid>
+            </Grid>   
             <Grid
               item
               xs={12}
               style={{ width: '100%', height: '38vh', border: '2px solid #0988ec', borderRadius: '0.5em', }}
             >
-              <Grid
-                container
-                direction="row"
-                justify="space-between"
-                style={{ height: '100%' }}
-              >
-                <Grid
-                  item
-                  style={{
-                    width: '48%',
-                    // border: '2px solid #0988ec',
-                    // borderRadius: '0.5em',
-                    height: '100%',
-                    overflow: 'auto',
-                  }}
-                >
-                  <Grid
-                    container
-                    direction="column"
-                    style={{ width: '100%' }}
-                  >
-                    <Grid item>
-                      <Grid
-                        container
-                        direction="row"
-                        justify="flex-start"
-                        alignItems="center"
-                        style={{ width: '100%' }}
-                      >
-                        <Grid item xs={11}>
-                          <Typography
+              <table style={{borderCollapse: 'collapse', width: '100%' }}>
+                <tr >
+                  <th style={{paddingBottom: '8px'}}></th>
+                  <th style={{textAlign: 'left', width: '55%', paddingBottom: '8px'}}><Typography
                             style={{
                               fontSize: '1em',
                               fontFamily:
                                 'Arimo',
                               marginLeft:
                                 '0.5em',
-                              marginTop:
-                                '0.5em',
                               fontWeight:
                                 'bold',
                             }}
                           >
-                            Action Steps
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={1}>
-                          <Grid
-                            container
-                            justify="flex-end"
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <InfoIcon
+                            Action Steps&ensp;
+                            <InfoIcon
                                 style={{
                                   fill:
                                     '#0988ec',
                                   marginRight:
-                                    '0.3em',
-                                  marginTop:
-                                    '0.3em',
+                                    '0.3em'
                                 }}
                                 onClick={(
                                   e: React.ChangeEvent<| HTMLInputElement
@@ -1541,145 +1500,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                                     </li>
                                   </ul>
                                 </div>
-                              </Popover>
-                            </Grid>
-                          </Grid>
-                        </Grid>
-                      </Grid>
-                    </Grid>
-                    <ol
-                      style={{
-                        paddingLeft: '1.5em',
-                        marginTop: '0.5em',
-                        marginBottom: 0,
-                      }}
-                    >
-                      {this.state.actionStepsArray.map(
-                        (value, index) => {
-                          return (
-                            <li key={index}>
-                              <TextField
-                                id={
-                                  'actionSteps' +
-                                  index.toString()
-                                }
-                                name={
-                                  'actionSteps' +
-                                  index.toString()
-                                }
-                                type="text"
-                                value={
-                                  value.step
-                                }
-                                onChange={this.handleChangeActionStep(
-                                  index,
-                                )}
-                                margin="normal"
-                                variant="standard"
-                                fullWidth
-                                multiline
-                                rowsMax={2}
-                                rows={2}
-                                className={
-                                  classes.textField
-                                }
-                                InputProps={{
-                                  disableUnderline: true,
-                                  readOnly: this
-                                    .props
-                                    .readOnly,
-                                  style: {
-                                    fontFamily:
-                                      'Arimo',
-                                    width:
-                                      '90%',
-                                    marginLeft:
-                                      '0.5em',
-                                    marginRight:
-                                      '0.5em',
-                                  },
-                                }}
-                                style={{
-                                  marginTop:
-                                    '-0.25em',
-                                  paddingBottom:
-                                    '0.5em',
-                                  marginBottom: 0,
-                                }}
-                              />
-                            </li>
-                          )
-                        },
-                      )}
-                    </ol>
-                    <Grid item>
-                      <Grid
-                        container
-                        direction="row"
-                        justify="flex-start"
-                        alignItems="center"
-                      >
-                        <Grid item xs={1}>
-                          <Button
-                            disabled={
-                              this.props
-                                .readOnly
-                            }
-                            onClick={
-                              this
-                                .handleAddActionStep
-                            }
-                            style={{
-                              marginLeft:
-                                '0.3em',
-                              paddingBottom:
-                                '0.5em',
-                            }}
-                          >
-                            <AddCircleIcon
-                              style={{
-                                fill: this
-                                  .props
-                                  .readOnly
-                                  ? '#a9a9a9'
-                                  : '#0988ec',
-                                marginRight:
-                                  '0.3em',
-                                marginTop:
-                                  '0.3em',
-                              }}
-                            />
-                          </Button>
-                        </Grid>
-                      </Grid>
-                    </Grid>
-                  </Grid>
-                </Grid>
-                <Grid
-                  item
-                  style={{
-                    width: '28%',
-                    // border: '2px solid #ffd300',
-                    // borderRadius: '0.5em',
-                    height: '100%',
-                    overflow: 'auto',
-                  }}
-                >
-                  <Grid
-                    container
-                    direction="column"
-                    style={{ width: '100%' }}
-                  >
-                    <Grid item>
-                      <Grid
-                        container
-                        direction="row"
-                        justify="flex-start"
-                        alignItems="center"
-                        style={{ width: '100%' }}
-                      >
-                        <Grid item xs={11}>
-                          <Typography
+                              </Popover></Typography></th>
+                  <th style={{textAlign: 'left', width:'22%', paddingBottom: '8px'}}><Typography
                             style={{
                               fontSize: '1em',
                               fontFamily:
@@ -1692,25 +1514,12 @@ class ActionPlanForm extends React.Component<Props, State> {
                                 'bold',
                             }}
                           >
-                            Persons
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={1}>
-                          <Grid
-                            container
-                            justify="flex-end"
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <InfoIcon
+                            Persons&ensp;<InfoIcon
                                 style={{
                                   fill:
                                     '#ffd300',
                                   marginRight:
-                                    '0.3em',
-                                  marginTop:
-                                    '0.3em',
+                                    '0.3em'
                                 }}
                                 onClick={(
                                   e: React.ChangeEvent<| HTMLInputElement
@@ -1815,138 +1624,24 @@ class ActionPlanForm extends React.Component<Props, State> {
                                   </ul>
                                 </div>
                               </Popover>
-                            </Grid>
-                          </Grid>
-                        </Grid>
-                      </Grid>
-                    </Grid>
-                    <Grid item>
-                      <ol
-                        style={{
-                          paddingLeft: '1.5em',
-                          marginTop: '0.5em',
-                          marginBottom: 0,
-                        }}
-                      >
-                        {this.state.actionStepsArray.map(
-                          (value, index) => {
-                            return (
-                              <li key={index}>
-                                <TextField
-                                  id={
-                                    'person' +
-                                    index.toString()
-                                  }
-                                  name={
-                                    'person' +
-                                    index.toString()
-                                  }
-                                  type="text"
-                                  value={
-                                    value.person
-                                  }
-                                  onChange={this.handleChangePerson(
-                                    index,
-                                  )}
-                                  margin="normal"
-                                  variant="standard"
-                                  fullWidth
-                                  multiline
-                                  rowsMax={
-                                    2
-                                  }
-                                  rows={2}
-                                  className={
-                                    classes.textField
-                                  }
-                                  InputProps={{
-                                    disableUnderline: true,
-                                    readOnly: this
-                                      .props
-                                      .readOnly,
-                                    style: {
-                                      fontFamily:
-                                        'Arimo',
-                                      width:
-                                        '90%',
-                                      marginLeft:
-                                        '0.5em',
-                                      marginRight:
-                                        '0.5em',
-                                    },
-                                  }}
-                                  style={{
-                                    marginTop:
-                                      '-0.25em',
-                                    paddingBottom:
-                                      '0.5em',
-                                    marginBottom: 0,
-                                  }}
-                                />
-                              </li>
-                            )
-                          },
-                        )}
-                      </ol>
-                    </Grid>
-                  </Grid>
-                </Grid>
-                <Grid
-                  item
-                  style={{
-                    width: '21%',
-                    // borderLeft: '2px solid #6f39c4',
-                    // borderRadius: '0.5em',
-                    height: '100%',
-                    overflow: 'auto',
-                  }}
-                >
-                  <Grid
-                    container
-                    direction="column"
-                    style={{ width: '100%' }}
-                  >
-                    <Grid item>
-                      <Grid
-                        container
-                        direction="row"
-                        justify="flex-start"
-                        alignItems="center"
-                        style={{ width: '100%' }}
-                      >
-                        <Grid item xs={11}>
-                          <Typography
+                          </Typography></th>
+                  <th style={{textAlign: 'left', width:'23%', paddingBottom: '8px'}}><Typography
                             style={{
                               fontSize: '1em',
                               fontFamily:
                                 'Arimo',
                               marginLeft:
                                 '0.5em',
-                              marginTop:
-                                '0.5em',
                               fontWeight:
                                 'bold',
                             }}
                           >
-                            Timeline
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={1}>
-                          <Grid
-                            container
-                            justify="flex-end"
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <InfoIcon
+                            Timeline&ensp;<InfoIcon
                                 style={{
                                   fill:
                                     '#6f39c4',
                                   marginRight:
-                                    '0.3em',
-                                  marginTop:
-                                    '0.3em',
+                                    '0.3em'
                                 }}
                                 onClick={(
                                   e: React.ChangeEvent<| HTMLInputElement
@@ -2061,24 +1756,114 @@ class ActionPlanForm extends React.Component<Props, State> {
                                   </ul>
                                 </div>
                               </Popover>
-                            </Grid>
-                          </Grid>
-                        </Grid>
-                      </Grid>
-                    </Grid>
-                    <Grid item>
-                      <ol
-                        style={{
-                          paddingLeft: '1.5em',
-                          marginTop: '0.5em',
-                          marginBottom: 0,
-                        }}
-                      >
-                        {this.state.actionStepsArray.map(
-                          (value, index) => {
-                            return (
-                              <li key={index}>
-                                <MuiPickersUtilsProvider
+                          </Typography></th>
+                </tr>
+                {this.state.actionStepsArray.map(
+                        (value, index) => {
+                          return (
+                            <tr style={{verticalAlign: 'top'}} key={index}>
+                              <td>{index+1+'.'}</td>
+                              <td><TextField
+                                id={
+                                  'actionSteps' +
+                                  index.toString()
+                                }
+                                name={
+                                  'actionSteps' +
+                                  index.toString()
+                                }
+                                type="text"
+                                value={
+                                  value.step
+                                }
+                                onChange={this.handleChangeActionStep(
+                                  index,
+                                )}
+                                margin="normal"
+                                variant="standard"
+                                fullWidth
+                                multiline
+                                // rowsMax={2}
+                                // rows={2}
+                                className={
+                                  classes.textField
+                                }
+                                InputProps={{
+                                  disableUnderline: true,
+                                  readOnly: this
+                                    .props
+                                    .readOnly,
+                                  style: {
+                                    fontFamily:
+                                      'Arimo',
+                                    width:
+                                      '90%',
+                                    marginLeft:
+                                      '0.5em',
+                                    marginRight:
+                                      '0.5em',
+                                  },
+                                }}
+                                style={{
+                                  marginTop:
+                                    '-0.25em',
+                                  paddingBottom:
+                                    '0.5em',
+                                  marginBottom: 0,
+                                }}
+                              /></td>
+                              <td><TextField
+                                  id={
+                                    'person' +
+                                    index.toString()
+                                  }
+                                  name={
+                                    'person' +
+                                    index.toString()
+                                  }
+                                  type="text"
+                                  value={
+                                    value.person
+                                  }
+                                  onChange={this.handleChangePerson(
+                                    index,
+                                  )}
+                                  margin="normal"
+                                  variant="standard"
+                                  fullWidth
+                                  multiline
+                                  // rowsMax={
+                                  //   2
+                                  // }
+                                  // rows={2}
+                                  className={
+                                    classes.textField
+                                  }
+                                  InputProps={{
+                                    disableUnderline: true,
+                                    readOnly: this
+                                      .props
+                                      .readOnly,
+                                    style: {
+                                      fontFamily:
+                                        'Arimo',
+                                      width:
+                                        '90%',
+                                      marginLeft:
+                                        '0.5em',
+                                      marginRight:
+                                        '0.5em',
+                                    },
+                                  }}
+                                  style={{
+                                    marginTop:
+                                      '-0.25em',
+                                    paddingBottom:
+                                      '0.5em',
+                                    marginBottom: 0,
+                                  }}
+                                /></td>
+                                <td style={{textAlign:'right'}}><MuiPickersUtilsProvider
                                   utils={
                                     DateFnsUtils
                                   }
@@ -2117,16 +1902,42 @@ class ActionPlanForm extends React.Component<Props, State> {
                                       )
                                     }}
                                   />
-                                </MuiPickersUtilsProvider>
-                              </li>
-                            )
-                          },
-                        )}
-                      </ol>
-                    </Grid>
-                  </Grid>
-                </Grid>
-              </Grid>
+                                </MuiPickersUtilsProvider></td>
+                            </tr>
+                          )
+                        },
+                      )}
+              </table>
+              <Button
+                            disabled={
+                              this.props
+                                .readOnly
+                            }
+                            onClick={
+                              this
+                                .handleAddActionStep
+                            }
+                            style={{
+                              marginLeft:
+                                '0.3em',
+                              paddingBottom:
+                                '0.5em',
+                            }}
+                          >
+                            <AddCircleIcon
+                              style={{
+                                fill: this
+                                  .props
+                                  .readOnly
+                                  ? '#a9a9a9'
+                                  : '#0988ec',
+                                marginRight:
+                                  '0.3em',
+                                marginTop:
+                                  '0.3em',
+                              }}
+                            />
+                          </Button>
             </Grid>
             <Grid
                 container
@@ -2153,7 +1964,28 @@ class ActionPlanForm extends React.Component<Props, State> {
                         style={{ width: '100%' }}
                       >
                         <Grid item> 
-                        <Button style={{ width: '100%' }} variant="contained">Send to Maintenance folder</Button>
+                        <Button 
+                        style={{ width: '100%' }} 
+                        variant="contained"
+                        onClick={
+                          this.handleCreate
+                        }
+                        ><Typography
+                        style={{
+                          fontSize: '1em',
+                          fontFamily:
+                            'Arimo',
+                          marginLeft:
+                            '0.5em',
+                          marginTop:
+                            '0.5em',
+                          fontWeight:
+                            'bold',
+                        }}
+                      >
+                        Send to Maintenance folder
+                      </Typography>
+                        </Button>
                   </Grid>
                 </Grid>
                 </Grid>

--- a/src/components/ActionPlanForm.tsx
+++ b/src/components/ActionPlanForm.tsx
@@ -81,6 +81,7 @@ interface State {
   createDialog: boolean
   dialog: boolean
   savedAlert: boolean
+  planNumber: Number
 }
 
 interface Style {
@@ -125,6 +126,7 @@ class ActionPlanForm extends React.Component<Props, State> {
       createDialog: false,
       dialog: false,
       savedAlert: false,
+      planNumber: 0
     }
   }
 
@@ -256,7 +258,7 @@ class ActionPlanForm extends React.Component<Props, State> {
 
   createNewActionPlan = (): void => {
     this.props.firebase
-      .createActionPlan(this.props.teacher.id, this.props.magic8)
+      .createActionPlan(this.props.teacher.id, this.props.magic8, this.state.planNumber)
       .then(() => {
         this.props.firebase.completeAppointment(
           this.props.teacher.id,
@@ -278,11 +280,16 @@ class ActionPlanForm extends React.Component<Props, State> {
       })
   }
 
+  handleYes = () => {
+    this.props.firebase.setActionPlanStatus(this.state.actionPlanId);
+    this.createNewActionPlan()
+  }
+
   /**
    * @param {string} actionPlanId
    */
-  getActionPlan = (actionPlanId: string): void => {
-    this.props.firebase
+  getActionPlan = async (actionPlanId: string) => {
+    await this.props.firebase
       .getAPInfo(actionPlanId)
       .then(
         (actionPlanData: {
@@ -295,6 +302,8 @@ class ActionPlanForm extends React.Component<Props, State> {
           coach: string
           teacher: string
           tool: string
+          planNum: number
+          status: string
         }) => {
           const newDate = this.changeDateType(
             actionPlanData.dateModified,
@@ -308,6 +317,7 @@ class ActionPlanForm extends React.Component<Props, State> {
                 : null,
             benefit: actionPlanData.benefit,
             date: newDate,
+            planNumber: actionPlanData.planNum ? actionPlanData.planNum : 1
           })
           const newActionStepsArray: Array<{
             step: string
@@ -547,18 +557,18 @@ class ActionPlanForm extends React.Component<Props, State> {
         {this.state.createDialog ? (
           <Dialog open={this.state.createDialog}>
             <DialogTitle style={{ fontFamily: 'Arimo' }}>
-              Create new Action Plan
+              Send Plan to Maintenance Folder
             </DialogTitle>
             <DialogContent>
               <DialogContentText>
-                Would you like to create a new Action Plan? You will not be able to edit the current one from this page.
+                Are you sure you want to send this action plan to the Maintenance Folder? Action plans in the maintenance folder cannot be re-opened for editing.
               </DialogContentText>
             </DialogContent>
             <DialogActions>
               <Button onClick={this.handleCloseCreate}>
                 No
               </Button>
-              <Button onClick={this.createNewActionPlan}>
+              <Button onClick={this.handleYes}>
                 Yes
               </Button>
             </DialogActions>
@@ -630,11 +640,11 @@ class ActionPlanForm extends React.Component<Props, State> {
                             fontFamily: 'Arimo',
                           }}
                         >
-                          ACTION PLAN
+                          {"ACTION PLAN " + this.state.planNumber}
                         </Typography>
                       </Grid>
                       <Grid item>
-                        <Button
+                        {/* <Button
                           onClick={
                             this.handleCreate
                           }
@@ -645,7 +655,7 @@ class ActionPlanForm extends React.Component<Props, State> {
                               fill: '#459aeb',
                             }}
                           />
-                        </Button>
+                        </Button> */}
                       </Grid>
                     </Grid>
                   </Grid>
@@ -1762,8 +1772,8 @@ class ActionPlanForm extends React.Component<Props, State> {
                         (value, index) => {
                           return (
                             <tr style={{verticalAlign: 'top'}} key={index}>
-                              <td>{index+1+'.'}</td>
-                              <td><TextField
+                              <td style={{paddingTop: '1.2em'}}>{index+1+'.'}</td>
+                              <td style={{paddingTop: '1.2em'}}><TextField
                                 id={
                                   'actionSteps' +
                                   index.toString()
@@ -1812,7 +1822,7 @@ class ActionPlanForm extends React.Component<Props, State> {
                                   marginBottom: 0,
                                 }}
                               /></td>
-                              <td><TextField
+                              <td style={{paddingTop: '1.2em'}}><TextField
                                   id={
                                     'person' +
                                     index.toString()
@@ -1939,7 +1949,7 @@ class ActionPlanForm extends React.Component<Props, State> {
                             />
                           </Button>
             </Grid>
-            <Grid
+            {this.props.history ? (<></>) : (<Grid
                 container
                 direction="row"
                 justify="flex-end"
@@ -1989,7 +1999,7 @@ class ActionPlanForm extends React.Component<Props, State> {
                   </Grid>
                 </Grid>
                 </Grid>
-                </Grid>
+                </Grid>)}
           </Grid>
         ) : (
           <div>

--- a/src/components/ActionPlanList.tsx
+++ b/src/components/ActionPlanList.tsx
@@ -83,6 +83,7 @@ interface ActionPlanInfo {
     }
     practice: string
     achieveBy: firebase.firestore.Timestamp
+    status: string
 }
 
 type ActionPlanInfoKey = keyof ActionPlanInfo
@@ -107,7 +108,7 @@ const headCells = [
         label: 'CHALK Practice',
     },
     {
-        id: 'achieveBy',
+        id: 'status',
         numeric: false,
         disablePadding: false,
         label: 'Status',
@@ -212,6 +213,7 @@ interface ActionPlanRow {
         nanoseconds: number
     }
     achieveBy: firebase.firestore.Timestamp
+    status: string
     teacherId: string
     practice: string
     teacherFirstName: string
@@ -661,6 +663,8 @@ class ActionPlanList extends React.Component<Props, State> {
      * @param index
      */
     renderActionPlanRow(row: ActionPlanRow, index: number): React.ReactNode {
+        console.log(row.status)
+        let status = row.status
         let achieveBy = row.achieveBy
         if (row.achieveBy && typeof row.achieveBy !== 'string') {
             // achieveBy is a string in legacy storage
@@ -797,9 +801,10 @@ class ActionPlanList extends React.Component<Props, State> {
                             fontFamily: 'Arimo',
                         }}
                     >
-                        {achieveBy
+                        {/* {achieveBy
                             ? moment(achieveBy).format('MM/DD/YYYY')
-                            : ''}
+                            : ''} */}
+                            {status ? status : ''}
                     </Typography>
                 </TableCell>
             </TableRow>

--- a/src/components/ActionPlanList.tsx
+++ b/src/components/ActionPlanList.tsx
@@ -110,7 +110,7 @@ const headCells = [
         id: 'achieveBy',
         numeric: false,
         disablePadding: false,
-        label: 'Achieve By:',
+        label: 'Status',
     },
 ]
 

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -2715,6 +2715,10 @@ class Firebase {
       )
   }
 
+  setActionPlanStatus = async ( actionPlanId: string ): Promise<void> => {
+    await firebase.firestore().collection('actionPlans').doc(actionPlanId).update({status: 'Maintenance'})
+  }
+
   /**
    * adds action plan entry to database
    * @param {string} teacherId
@@ -2722,7 +2726,8 @@ class Firebase {
    */
   createActionPlan = async (
     teacherId: string,
-    magic8: string
+    magic8: string,
+    planNumber: number
   ): Promise<string | void> => {
     const data = Object.assign(
       {},
@@ -2735,6 +2740,8 @@ class Firebase {
         goal: '',
         goalTimeline: '',
         benefit: '',
+        planNum: (planNumber > 0) ? planNumber+1 : 1 ,
+        status: "Active"
       }
     )
     const actionPlansRef = firebase
@@ -2803,6 +2810,7 @@ class Firebase {
     teacherFirstName: string
     teacherLastName: string
     achieveBy: firebase.firestore.Timestamp
+    status: string
   }> | void> => {
     if (this.auth.currentUser) {
       this.query = this.db
@@ -2820,6 +2828,7 @@ class Firebase {
             modified: number
             teacherLastName: string
             achieveBy: firebase.firestore.Timestamp
+            status: string
           }> = []
           querySnapshot.forEach(doc => {
               // Moved the logic for 'modified' here so it sorts correctly in the Action Plan List
@@ -2834,6 +2843,7 @@ class Firebase {
                 achieveBy: doc.data().goalTimeline
                   ? doc.data().goalTimeline
                   : firebase.firestore.Timestamp.fromDate(new Date()),
+                status: doc.data().status
               })
             }
           )


### PR DESCRIPTION
The action plan form in the results section has been made to create a new action plan if there is none available and number it accordingly instead of needing to use the blue plus button. The blue plus button has been removed because of this as requested.

A new button labeled "Send to Maintenance Folder" has been added and clicking results in a popup that displays the requested text and buttons. Clicking yes in this popup will label the current action plan's status as "Maintenance" and create a new action plan with the status "Active"

The Action plan list header "Achieve by" has been replaced with "Status" and will now show the status of all action plans.