### PR TITLE
Bug/issue607

### DIFF
--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -314,15 +314,32 @@ class Firebase {
     }
   }
 
-  // adds custom favorite questions
-  addFavoriteQuestion = async (question: string[]): Promise<Array<firebase.firestore.DocumentData> | void | undefined> => {
+  fetchCustomQuestions = async (magic8: string): Promise<Array<string> | void | undefined> => {
     if (this.auth.currentUser) {
       return this.db.collection('users').doc(this.auth.currentUser.uid).get()
       .then(user => {
         const favoriteQuestions = user.data().favoriteQuestions || []
-      const newFavoriteQuestions = favoriteQuestions.includes(question) ? favoriteQuestions.filter(
-        favoriteQuestions => favoriteQuestions !== question
-      ) : [question, ...favoriteQuestions]
+        const questionList: Array<string> = []
+          favoriteQuestions.forEach(question => {
+            if (question.includes(magic8 + ': ')) {
+              questionList.push(question.split(magic8 + ': ')[1])
+            }
+          })
+          console.log(questionList)
+          return questionList
+      })
+    }
+  }
+
+  // adds custom favorite questions
+  addFavoriteQuestion = async (question: string[], magic8: string): Promise<Array<firebase.firestore.DocumentData> | void | undefined> => {
+    if (this.auth.currentUser) {
+      return this.db.collection('users').doc(this.auth.currentUser.uid).get()
+      .then(user => {
+        const favoriteQuestions = user.data().favoriteQuestions || []
+      const newFavoriteQuestions = favoriteQuestions.includes(magic8 + ': ' + question) ? favoriteQuestions.filter(
+        favoriteQuestions => favoriteQuestions !== magic8 + ': ' + question
+      ) : [magic8 + ': ' + question, ...favoriteQuestions]
       return this.db.collection('users').doc(this.auth.currentUser.uid).update({
         favoriteQuestions: newFavoriteQuestions,
       }).catch((error: Error) =>

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -314,6 +314,27 @@ class Firebase {
     }
   }
 
+  // adds custom favorite questions
+  addFavoriteQuestion = async (question: string[]): Promise<Array<firebase.firestore.DocumentData> | void | undefined> => {
+    if (this.auth.currentUser) {
+      return this.db.collection('users').doc(this.auth.currentUser.uid).get()
+      .then(user => {
+        const favoriteQuestions = user.data().favoriteQuestions || []
+      const newFavoriteQuestions = favoriteQuestions.includes(question) ? favoriteQuestions.filter(
+        favoriteQuestions => favoriteQuestions !== question
+      ) : [question, ...favoriteQuestions]
+      return this.db.collection('users').doc(this.auth.currentUser.uid).update({
+        favoriteQuestions: newFavoriteQuestions,
+      }).catch((error: Error) =>
+      console.error('Error updating favorite questions list: ', error)
+    )
+      }).catch((error: Error) =>
+      console.error('Error getting favorite questions list: ', error)
+    )
+    }
+  }
+
+  // adds favorite questions from constants
   updateFavouriteQuestions = async (
     questionId: string[]
   ): Promise<Array<firebase.firestore.DocumentData> | void | undefined> => {

--- a/src/components/ResultsComponents/DataQuestions.tsx
+++ b/src/components/ResultsComponents/DataQuestions.tsx
@@ -58,6 +58,7 @@ interface Props {
 interface State {
     favouriteQuestions: array,
     questions: Array<string>,
+    addedQuestions: Array<string>,
 }
 
 /**
@@ -73,6 +74,7 @@ class DataQuestions extends React.Component<Props, State> {
         this.state = {
             user: {},
             questions: [''],
+            addedQuestions: [''],
         }
     }
 
@@ -100,6 +102,7 @@ class DataQuestions extends React.Component<Props, State> {
     async componentDidMount(): void {
         this.setState({
             user: await this.context.getUserInformation(),
+            addedQuestions: await this.context.fetchCustomQuestions(this.props.magic8)
         })
     }
 
@@ -109,17 +112,16 @@ class DataQuestions extends React.Component<Props, State> {
         this.setState({ user: await this.context.getUserInformation() })
     }
 
-    async addQuestion(value) {
-        await this.context.addFavoriteQuestion(value)
-        this.setState({ user: await this.context.getUserInformation() })
-    }
-
-    handleAddQuestion = (): void => {
-        this.setState({
-          questions: [...this.state.questions, '']
+    async addQuestion(value, tool) {
+        if (value !== '') {
+        await this.context.addFavoriteQuestion(value, tool)
+        this.setState({ 
+            user: await this.context.getUserInformation(), 
+            addedQuestions: await this.context.fetchCustomQuestions(this.props.magic8),
+            questions: ['']
         })
-      }
-
+        }
+    }
 
     handleChangeQuestions = (number: number) => (event: React.ChangeEvent<HTMLInputElement>): void => {
         const newArray = [...this.state.questions];
@@ -240,7 +242,7 @@ class DataQuestions extends React.Component<Props, State> {
                                         </Grid>
                                     ))}
                                     {item.title === "FAQ" ? (<>
-                                    {this.state.questions.map((value, index) => {
+                                    {this.state.addedQuestions[0] ? this.state.addedQuestions.map((value, index) => {
                                     return (
                                         <Grid
                                             container
@@ -254,24 +256,17 @@ class DataQuestions extends React.Component<Props, State> {
                                             id={"questions" + index.toString()}
                                             name={"questions" + index.toString()}
                                             type="text"
-                                            placeholder={
-                                            !this.state.questions[0] && index===0
-                                                ? "Type your questions here and click the star to save, or add them from the Questions tabs!"
-                                                : "Type your question here!"
-                                            }
                                             value={value}
-                                            onChange={this.handleChangeQuestions(index)}
                                             margin="none"
                                             variant="standard"
                                             fullWidth
                                             multiline
                                             InputProps={{
                                             disableUnderline: true,
-                                            // readOnly: this.props.readOnly,
+                                            readOnly: true,
                                             style: {fontFamily: "Arimo", width: '98%', marginLeft: '2.4em'}
                                             }}
                                             InputLabelProps={{style: {fontSize: 20, marginLeft: '0.5em', fontFamily: "Arimo"}}}
-                                            // className={classes.textField}
                                         />
                                         </Grid>
                                         <Grid item xs={1}>
@@ -297,40 +292,63 @@ class DataQuestions extends React.Component<Props, State> {
                                             <Grid item xs={1}>
                                                 <Button
                                                     onClick={(): void => {
-                                                        this.addQuestion(value) //id
-                                                        console.log(item.name)
-                                                        console.log(index)
-                                                        console.log(value)
+                                                        this.addQuestion(value, this.props.magic8) //id
                                                     }}
                                                 >
-                                                    {this.state.user?.favouriteQuestions?.includes(
-                                                        index //id
-                                                    ) ? (
                                                         <Star
                                                             style={{
                                                                 fill: this.props
                                                                     .color,
                                                             }}
                                                         />
-                                                    ) : (
+                                                </Button>
+                                            </Grid>
+                                    </Grid>
+                                    )}): (<></>)}
+                                    {this.state.questions.map((value, index) => {
+                                    return (
+                                        <Grid
+                                            container
+                                            direction="row"
+                                            alignItems="center"
+                                            key={index}
+                                            style={{marginTop:"0.5em", marginBottom:'0.5em'}}
+                                        >
+                                        <Grid item xs={11}>
+                                        <TextField
+                                            id={"questions" + index.toString()}
+                                            name={"questions" + index.toString()}
+                                            type="text"
+                                            placeholder='Type your questions here and click the star to save, or add them from one of the category tabs!'
+                                            value={value}
+                                            onChange={this.handleChangeQuestions(index)}
+                                            margin="none"
+                                            variant="standard"
+                                            fullWidth
+                                            multiline
+                                            InputProps={{
+                                            disableUnderline: true,
+                                            style: {fontFamily: "Arimo", width: '98%', marginLeft: '2.4em'}
+                                            }}
+                                            InputLabelProps={{style: {fontSize: 20, marginLeft: '0.5em', fontFamily: "Arimo"}}}
+                                        />
+                                        </Grid>
+                                            <Grid item xs={1}>
+                                                <Button
+                                                    onClick={(): void => {
+                                                        this.addQuestion(value, this.props.magic8)
+                                                    }}
+                                                >
                                                         <StarBorder
                                                             style={{
                                                                 fill: this.props
                                                                     .color,
                                                             }}
                                                         />
-                                                    )}
                                                 </Button>
                                             </Grid>
                                     </Grid>
                                     )})}
-                                    <Grid item>
-                                    <Grid container direction="row" justify="center">
-                                        <Button onClick={this.handleAddQuestion}>
-                                        <AddCircleIcon style={{fill: this.props.color}} />
-                                        </Button>
-                                    </Grid>
-                                    </Grid>
                                     </>) : (<></>)}
                                 </Grid>
                             </ExpansionPanelDetails>

--- a/src/components/ResultsComponents/DataQuestions.tsx
+++ b/src/components/ResultsComponents/DataQuestions.tsx
@@ -58,7 +58,6 @@ interface Props {
 interface State {
     favouriteQuestions: array,
     questions: Array<string>,
-    addedQuestions: Array<string>,
 }
 
 /**
@@ -74,7 +73,6 @@ class DataQuestions extends React.Component<Props, State> {
         this.state = {
             user: {},
             questions: [''],
-            addedQuestions: [],
         }
     }
 
@@ -108,6 +106,11 @@ class DataQuestions extends React.Component<Props, State> {
     // eslint-disable-next-line require-jsdoc
     async toggleQuestion(id) {
         await this.context.updateFavouriteQuestions(id)
+        this.setState({ user: await this.context.getUserInformation() })
+    }
+
+    async addQuestion(value) {
+        await this.context.addFavoriteQuestion(value)
         this.setState({ user: await this.context.getUserInformation() })
     }
 
@@ -252,8 +255,8 @@ class DataQuestions extends React.Component<Props, State> {
                                             name={"questions" + index.toString()}
                                             type="text"
                                             placeholder={
-                                            !this.state.addedQuestions[0] && index===0
-                                                ? "Type your questions here and click the star to save!"
+                                            !this.state.questions[0] && index===0
+                                                ? "Type your questions here and click the star to save, or add them from the Questions tabs!"
                                                 : "Type your question here!"
                                             }
                                             value={value}
@@ -294,7 +297,10 @@ class DataQuestions extends React.Component<Props, State> {
                                             <Grid item xs={1}>
                                                 <Button
                                                     onClick={(): void => {
-                                                        this.toggleQuestion(index) //id
+                                                        this.addQuestion(value) //id
+                                                        console.log(item.name)
+                                                        console.log(index)
+                                                        console.log(value)
                                                     }}
                                                 >
                                                     {this.state.user?.favouriteQuestions?.includes(

--- a/src/components/ResultsComponents/DataQuestions.tsx
+++ b/src/components/ResultsComponents/DataQuestions.tsx
@@ -13,6 +13,9 @@ import StarBorder from '@material-ui/icons/StarBorder'
 import Button from '@material-ui/core/Button'
 import Grid from '@material-ui/core/Grid'
 import { FirebaseContext } from '../Firebase'
+import TextField from '@material-ui/core/TextField'
+import AddCircleIcon from "@material-ui/icons/AddCircle";
+
 
 const styles: object = {
     expansionPanel: {
@@ -53,7 +56,9 @@ interface Props {
 }
 
 interface State {
-    favouriteQuestions: array
+    favouriteQuestions: array,
+    questions: Array<string>,
+    addedQuestions: Array<string>,
 }
 
 /**
@@ -68,6 +73,8 @@ class DataQuestions extends React.Component<Props, State> {
         super(props)
         this.state = {
             user: {},
+            questions: [''],
+            addedQuestions: [],
         }
     }
 
@@ -103,6 +110,21 @@ class DataQuestions extends React.Component<Props, State> {
         await this.context.updateFavouriteQuestions(id)
         this.setState({ user: await this.context.getUserInformation() })
     }
+
+    handleAddQuestion = (): void => {
+        this.setState({
+          questions: [...this.state.questions, '']
+        })
+      }
+
+
+    handleChangeQuestions = (number: number) => (event: React.ChangeEvent<HTMLInputElement>): void => {
+        const newArray = [...this.state.questions];
+        newArray[number] = event.target.value;
+        this.setState({
+            questions: newArray,
+        });
+    }  
 
     /**
      * render function
@@ -214,6 +236,96 @@ class DataQuestions extends React.Component<Props, State> {
                                             </Grid>
                                         </Grid>
                                     ))}
+                                    {item.title === "FAQ" ? (<>
+                                    {this.state.questions.map((value, index) => {
+                                    return (
+                                        <Grid
+                                            container
+                                            direction="row"
+                                            alignItems="center"
+                                            key={index}
+                                            style={{marginTop:"0.5em", marginBottom:'0.5em'}}
+                                        >
+                                        <Grid item xs={10}>
+                                        <TextField
+                                            id={"questions" + index.toString()}
+                                            name={"questions" + index.toString()}
+                                            type="text"
+                                            placeholder={
+                                            !this.state.addedQuestions[0] && index===0
+                                                ? "Type your questions here and click the star to save!"
+                                                : "Type your question here!"
+                                            }
+                                            value={value}
+                                            onChange={this.handleChangeQuestions(index)}
+                                            margin="none"
+                                            variant="standard"
+                                            fullWidth
+                                            multiline
+                                            InputProps={{
+                                            disableUnderline: true,
+                                            // readOnly: this.props.readOnly,
+                                            style: {fontFamily: "Arimo", width: '98%', marginLeft: '2.4em'}
+                                            }}
+                                            InputLabelProps={{style: {fontSize: 20, marginLeft: '0.5em', fontFamily: "Arimo"}}}
+                                            // className={classes.textField}
+                                        />
+                                        </Grid>
+                                        <Grid item xs={1}>
+                                                <Button
+                                                    onClick={this.props.handleAddToPlan.bind(
+                                                        this,
+                                                        item.name,
+                                                        index,
+                                                        value,
+                                                        this.props.sessionId,
+                                                        this.props.teacherId,
+                                                        this.props.magic8
+                                                    )}
+                                                >
+                                                    <AddIcon
+                                                        style={{
+                                                            fill: this.props
+                                                                .color,
+                                                        }}
+                                                    />
+                                                </Button>
+                                            </Grid>
+                                            <Grid item xs={1}>
+                                                <Button
+                                                    onClick={(): void => {
+                                                        this.toggleQuestion(index) //id
+                                                    }}
+                                                >
+                                                    {this.state.user?.favouriteQuestions?.includes(
+                                                        index //id
+                                                    ) ? (
+                                                        <Star
+                                                            style={{
+                                                                fill: this.props
+                                                                    .color,
+                                                            }}
+                                                        />
+                                                    ) : (
+                                                        <StarBorder
+                                                            style={{
+                                                                fill: this.props
+                                                                    .color,
+                                                            }}
+                                                        />
+                                                    )}
+                                                </Button>
+                                            </Grid>
+                                    </Grid>
+                                    )})}
+                                    <Grid item>
+                                    <Grid container direction="row" justify="center">
+                                        <Button onClick={this.handleAddQuestion}>
+                                        <AddCircleIcon style={{fill: this.props.color}} />
+                                        </Button>
+                                    </Grid>
+                                    </Grid>
+                                    </>) : (<></>)}
                                 </Grid>
                             </ExpansionPanelDetails>
                         </ExpansionPanel>


### PR DESCRIPTION
The ability to add custom favorite questions has been added in the Favorite Questions category of the Coaching Questions tab in the results screen.

A text field will be available only in the FAQ of the Favorite Questions section to type a question and will save upon clicking the star to the right. After the question has been saved you will then be able to send it to a conference plan or un-save the question as a favorite. You must click the star to save the question. After the question is saved another text field will appear below the new saved question so you can add another.