### PR TITLE
Made exports include end date and prevent long ws names

### DIFF
--- a/functions/exportBqData/index.js
+++ b/functions/exportBqData/index.js
@@ -107,6 +107,11 @@ exports.exportBqData = functions.https.onCall(async (data, context) => {
     return ''
   }
 
+  let newTo = new Date(data.to);
+  newTo.setDate(newTo.getDate() + 1);
+  newTo = newTo.toISOString().split("T")[0]
+
+
   const sqlQuery = `select * from ${functions.config().env.bq_project}.${functions.config().env.bq_dataset}.${table} where sessionStart > @from and sessionEnd < @to order by id`
 
   const options = {
@@ -115,7 +120,7 @@ exports.exportBqData = functions.https.onCall(async (data, context) => {
     location: 'US',
     params: {
       from: data.from,
-      to: data.to,
+      to: newTo,
     },
   }
 

--- a/src/components/AdminComponents/ObservationsExport.tsx
+++ b/src/components/AdminComponents/ObservationsExport.tsx
@@ -101,7 +101,7 @@ const generateExcel = async (
 
   const wb = xlsx.utils.book_new()
   results.forEach(r => {
-    const wsName = r.table
+    const wsName = r.table.substring(0, 31)
     if (r.data.data) {
       const wsData = r.data.data.split('\n')
         .map(d => d.split(',').map(r => maybeTransformForTime(r)))

--- a/src/components/AdminComponents/ObservationsExport.tsx
+++ b/src/components/AdminComponents/ObservationsExport.tsx
@@ -110,7 +110,12 @@ const generateExcel = async (
     }
   })
 
-  xlsx.writeFile(wb, 'CoachingAppExport.xlsx')
+  try {
+    xlsx.writeFile(wb, 'CoachingAppExport.xlsx');
+  } catch (err) {
+    console.log("Error writing the file: ", err);
+    window.alert("Workbook is empty!")
+  }
   setLoading(false)
 }
 


### PR DESCRIPTION
This pull request addresses a recent issue where exports where not being generated. 

Updates
 - The end date was changed to be included in the retrieval from BigQuery 
 - Worksheet names are a 31 character substring of the original name to align with xlsx naming rules
 - A try catch handles issues with not generating a spreadsheet removing the infinite owl logo and alerting the user via dialog box
