### PR TITLE
Remove unused Firebase Function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -103,4 +103,3 @@ exports.exportBqData = require('./exportBqData').exportBqData;
 
 exports.funcAddToTransferLogsOnUpdate = require('./funcAddToTransferLogs').funcAddToTransferLogsOnUpdate;
 exports.funcAddToTransferLogsOnPartnerCreate = require('./funcAddToTransferLogs').funcAddToTransferLogsOnPartnerCreate;
-exports.retrieveTableFromFirestore = require('./retrieveTableFromFirestore').retrieveTableFromFirestore;


### PR DESCRIPTION
The 'retrieveTableFromFirestore' function had code that attempts to read data from firestore and BQ outside of the Firebase trigger. This causes the code to run automatically on deployment. Removing it from imports just for peace of mind.