### PR TITLE
chore(release): merge develop into master with login tracking feature

### DIFF
--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -321,6 +321,10 @@ class Firebase {
           await this.db.collection('users').doc(userCredential.user.uid).update({
             lastLogin: firebase.firestore.FieldValue.serverTimestamp()
           })
+          await this.db.collection('loginEvents').add({
+            userId: userCredential.user.uid,
+            timestamp: firebase.firestore.FieldValue.serverTimestamp()
+          })
         }
         return userCredential
       })
@@ -4842,6 +4846,26 @@ class Firebase {
     })
 
     return lastActionMap
+  }
+
+  getUsersLoginCounts = async (
+    startDate: Date,
+    endDate: Date
+  ): Promise<Map<string, number>> => {
+    const counts = new Map<string, number>()
+    const snapshot = await this.db
+      .collection('loginEvents')
+      .where('timestamp', '>=', startDate)
+      .where('timestamp', '<=', endDate)
+      .get()
+
+    snapshot.docs.forEach(doc => {
+      const userId = doc.data().userId
+      if (!userId) return
+      counts.set(userId, (counts.get(userId) || 0) + 1)
+    })
+
+    return counts
   }
 
   getAllUsers = async () => {

--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -12,6 +12,8 @@ import {
   Switch,
   Tooltip,
 } from '@material-ui/core'
+import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers'
+import DateFnsUtils from '@date-io/date-fns'
 import React from 'react'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import EditIcon from '@material-ui/icons/Edit'
@@ -43,6 +45,10 @@ const StatusBadge = styled.span<{ archived: boolean }>`
 
 interface Props {
   users: Types.User[]
+  loginCounts: Map<string, number>
+  rangeStart: Date
+  rangeEnd: Date
+  onRangeChange: (start: Date, end: Date) => void
   onUserClick?: (user: Types.User) => void
   onArchiveClick?: (user: Types.User) => void
 }
@@ -90,12 +96,19 @@ class AllUsersTable extends React.Component<Props, State> {
 
     users.sort((a, b) => {
       const isDateField = sortField === 'lastLogin' || sortField === 'lastAction'
-      const aVal = isDateField
-        ? (a[sortField]?.getTime() || 0)
-        : String(a[sortField] || '').toLowerCase()
-      const bVal = isDateField
-        ? (b[sortField]?.getTime() || 0)
-        : String(b[sortField] || '').toLowerCase()
+      const isLoginCount = sortField === 'loginCount'
+      let aVal: number | string
+      let bVal: number | string
+      if (isLoginCount) {
+        aVal = this.props.loginCounts.get(a.id) || 0
+        bVal = this.props.loginCounts.get(b.id) || 0
+      } else if (isDateField) {
+        aVal = a[sortField]?.getTime() || 0
+        bVal = b[sortField]?.getTime() || 0
+      } else {
+        aVal = String(a[sortField] || '').toLowerCase()
+        bVal = String(b[sortField] || '').toLowerCase()
+      }
       return sortDir === 'asc' ? (aVal > bVal ? 1 : -1) : (aVal < bVal ? 1 : -1)
     })
 
@@ -115,15 +128,33 @@ class AllUsersTable extends React.Component<Props, State> {
     return user.lastActionType ? `${user.lastActionType} - ${date}` : date
   }
 
+  formatRangeLabel = () => {
+    const fmt = (d: Date) => d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+    return `${fmt(this.props.rangeStart)} \u2013 ${fmt(this.props.rangeEnd)}`
+  }
+
+  applyPreset = (days: number) => {
+    const end = new Date()
+    end.setHours(23, 59, 59, 999)
+    const start = new Date()
+    start.setDate(start.getDate() - days + 1)
+    start.setHours(0, 0, 0, 0)
+    this.props.onRangeChange(start, end)
+  }
+
   handleExport = () => {
     const users = this.getFilteredUsers()
-    const headers = ['Last Name', 'First Name', 'Email', 'Role', 'Program', 'Status', 'Last Login', 'Last Action', 'Action Type']
+    const headers = [
+      'Last Name', 'First Name', 'Email', 'Role', 'Program', 'Status',
+      'Last Login', `Logins (${this.formatRangeLabel()})`, 'Last Action', 'Action Type'
+    ]
     const escape = (val: string) => `"${(val || '').replace(/"/g, '""')}"`
     const rows = users.map(u => [
       escape(u.lastName), escape(u.firstName), escape(u.email),
       escape(this.formatRole(u.role)), escape(u.program || ''),
       escape(u.archived ? 'Archived' : 'Active'),
       escape(this.formatDate(u.lastLogin)),
+      String(this.props.loginCounts.get(u.id) || 0),
       escape(this.formatDate(u.lastAction)),
       escape(u.lastActionType || '')
     ].join(','))
@@ -148,6 +179,8 @@ class AllUsersTable extends React.Component<Props, State> {
         </TableSortLabel>
       </th>
     )
+
+    const { rangeStart, rangeEnd, onRangeChange } = this.props
 
     return (
       <Grid container direction="column" spacing={2}>
@@ -177,6 +210,25 @@ class AllUsersTable extends React.Component<Props, State> {
           </Button>
         </Grid>
 
+        <Grid item style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: '#555' }}>Login range:</span>
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <KeyboardDatePicker
+              disableToolbar variant="inline" format="MM/dd/yy" margin="none"
+              autoOk label="From" value={rangeStart} style={{ width: 150 }}
+              onChange={(date: Date | null) => date && onRangeChange(date, rangeEnd)}
+            />
+            <KeyboardDatePicker
+              disableToolbar variant="inline" format="MM/dd/yy" margin="none"
+              autoOk label="To" value={rangeEnd} style={{ width: 150 }}
+              onChange={(date: Date | null) => date && onRangeChange(rangeStart, date)}
+            />
+          </MuiPickersUtilsProvider>
+          <Button size="small" variant="outlined" onClick={() => this.applyPreset(7)}>Last 7d</Button>
+          <Button size="small" variant="outlined" onClick={() => this.applyPreset(30)}>Last 30d</Button>
+          <Button size="small" variant="outlined" onClick={() => this.applyPreset(90)}>Last 90d</Button>
+        </Grid>
+
         <Grid item style={{ overflowX: 'auto' }}>
           <table style={{ borderCollapse: 'collapse', width: '100%', minWidth: 800 }}>
             <thead style={{ borderBottom: '2px solid #0988ec' }}>
@@ -188,13 +240,14 @@ class AllUsersTable extends React.Component<Props, State> {
                 <SortHeader field="program" label="Program" />
                 <SortHeader field="archived" label="Status" />
                 <SortHeader field="lastLogin" label="Last Login" />
+                <SortHeader field="loginCount" label={`Logins (${this.formatRangeLabel()})`} />
                 <SortHeader field="lastAction" label="Last Action" />
                 <th style={{ padding: '4px 8px', textAlign: 'center', fontSize: '1.25rem', fontWeight: 500 }}><strong>Edit</strong></th>
               </tr>
             </thead>
             <tbody>
               {paginated.length === 0 ? (
-                <tr><TableCell colSpan={9} style={{ textAlign: 'center', padding: 40 }}>No users found</TableCell></tr>
+                <tr><TableCell colSpan={10} style={{ textAlign: 'center', padding: 40 }}>No users found</TableCell></tr>
               ) : paginated.map(user => (
                 <TableRow key={user.id}>
                   <TableCell>{user.lastName}</TableCell>
@@ -214,6 +267,7 @@ class AllUsersTable extends React.Component<Props, State> {
                     </Tooltip>
                   </TableCell>
                   <TableCell>{this.formatDate(user.lastLogin)}</TableCell>
+                  <TableCell>{this.props.loginCounts.get(user.id) || 0}</TableCell>
                   <TableCell>{this.formatLastAction(user)}</TableCell>
                   <TableCell onClick={e => e.stopPropagation()} style={{ textAlign: 'center' }}>
                     <Tooltip title="Edit user">

--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -146,7 +146,7 @@ class AllUsersTable extends React.Component<Props, State> {
     const users = this.getFilteredUsers()
     const headers = [
       'Last Name', 'First Name', 'Email', 'Role', 'Program', 'Status',
-      'Last Login', `Logins (${this.formatRangeLabel()})`, 'Last Action', 'Action Type'
+      'Last Login', `Login Count (${this.formatRangeLabel()})`, 'Last Action', 'Action Type'
     ]
     const escape = (val: string) => `"${(val || '').replace(/"/g, '""')}"`
     const rows = users.map(u => [
@@ -172,7 +172,7 @@ class AllUsersTable extends React.Component<Props, State> {
     const paginated = filtered.slice(page * perPage, (page + 1) * perPage)
     const roles = [...new Set(this.props.users.map(u => u.role))].sort()
 
-    const SortHeader = ({ field, label }: { field: string; label: string }) => (
+    const SortHeader = ({ field, label }: { field: string; label: React.ReactNode }) => (
       <th style={{ padding: '4px 8px', cursor: 'pointer', fontSize: '1.25rem', fontWeight: 500 }} onClick={() => this.handleSort(field)}>
         <TableSortLabel active={sortField === field} direction={sortField === field ? sortDir : 'asc'}>
           <strong>{label}</strong>
@@ -240,7 +240,7 @@ class AllUsersTable extends React.Component<Props, State> {
                 <SortHeader field="program" label="Program" />
                 <SortHeader field="archived" label="Status" />
                 <SortHeader field="lastLogin" label="Last Login" />
-                <SortHeader field="loginCount" label={`Logins (${this.formatRangeLabel()})`} />
+                <SortHeader field="loginCount" label={<span style={{ display: 'inline-flex', flexDirection: 'column', lineHeight: 1.2 }}>Login Count<span style={{ fontSize: '0.75rem', fontWeight: 400, color: '#666' }}>{this.formatRangeLabel()}</span></span>} />
                 <SortHeader field="lastAction" label="Last Action" />
                 <th style={{ padding: '4px 8px', textAlign: 'center', fontSize: '1.25rem', fontWeight: 500 }}><strong>Edit</strong></th>
               </tr>

--- a/src/views/protected/AdminViews/AllUsersPage.tsx
+++ b/src/views/protected/AdminViews/AllUsersPage.tsx
@@ -12,6 +12,9 @@ interface Props { isAdmin: boolean }
 interface State {
   loading: boolean
   users: Types.User[]
+  loginCounts: Map<string, number>
+  rangeStart: Date
+  rangeEnd: Date
   editOpen: boolean
   archiveOpen: boolean
   selected: Types.User | null
@@ -20,19 +23,41 @@ interface State {
   email: string
 }
 
+const defaultRange = (): { start: Date; end: Date } => {
+  const end = new Date()
+  end.setHours(23, 59, 59, 999)
+  const start = new Date()
+  start.setDate(start.getDate() - 29)
+  start.setHours(0, 0, 0, 0)
+  return { start, end }
+}
+
 class AllUsersPage extends React.Component<Props, State> {
   static contextType = FirebaseContext
   context!: Firebase
 
   state: State = {
-    loading: true, users: [], editOpen: false, archiveOpen: false,
+    loading: true, users: [], loginCounts: new Map(),
+    rangeStart: defaultRange().start, rangeEnd: defaultRange().end,
+    editOpen: false, archiveOpen: false,
     selected: null, firstName: '', lastName: '', email: '',
   }
 
   componentDidMount() {
-    this.context.getAllUsers()
-      .then(users => this.setState({ users, loading: false }))
+    const { rangeStart, rangeEnd } = this.state
+    Promise.all([
+      this.context.getAllUsers(),
+      this.context.getUsersLoginCounts(rangeStart, rangeEnd)
+    ])
+      .then(([users, loginCounts]) => this.setState({ users, loginCounts, loading: false }))
       .catch(() => { alert('Error loading users'); this.setState({ loading: false }) })
+  }
+
+  handleRangeChange = (start: Date, end: Date) => {
+    this.setState({ rangeStart: start, rangeEnd: end })
+    this.context.getUsersLoginCounts(start, end)
+      .then(loginCounts => this.setState({ loginCounts }))
+      .catch(() => alert('Error loading login counts'))
   }
 
   handleUserClick = (user: Types.User) => {
@@ -66,7 +91,7 @@ class AllUsersPage extends React.Component<Props, State> {
 
   render() {
     const { isAdmin } = this.props
-    const { loading, users, editOpen, archiveOpen, selected, firstName, lastName, email } = this.state
+    const { loading, users, loginCounts, rangeStart, rangeEnd, editOpen, archiveOpen, selected, firstName, lastName, email } = this.state
 
     return (
       <div style={{ height: '100vh', overflow: 'auto' }}>
@@ -86,6 +111,10 @@ class AllUsersPage extends React.Component<Props, State> {
             ) : (
               <AllUsersTable
                 users={users}
+                loginCounts={loginCounts}
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                onRangeChange={this.handleRangeChange}
                 onUserClick={this.handleUserClick}
                 onArchiveClick={user => this.setState({ selected: user, archiveOpen: true })}
               />

--- a/src/views/protected/UsersViews/UsersPage.tsx
+++ b/src/views/protected/UsersViews/UsersPage.tsx
@@ -113,6 +113,9 @@ interface State {
   sendToSites: Array<Object>
   allUsers: Types.User[]
   allUsersLoading: boolean
+  allUsersLoginCounts: Map<string, number>
+  allUsersRangeStart: Date
+  allUsersRangeEnd: Date
   editDialogOpen: boolean
   archiveDialogOpen: boolean
   selectedUser: Types.User | null
@@ -138,6 +141,12 @@ class UsersPage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    const rangeEnd = new Date()
+    rangeEnd.setHours(23, 59, 59, 999)
+    const rangeStart = new Date()
+    rangeStart.setDate(rangeStart.getDate() - 29)
+    rangeStart.setHours(0, 0, 0, 0)
+
     this.state = {
       currentPage: "",
       coachData: [],
@@ -150,6 +159,9 @@ class UsersPage extends React.Component<Props, State> {
       sendToSites: [],
       allUsers: [],
       allUsersLoading: true,
+      allUsersLoginCounts: new Map(),
+      allUsersRangeStart: rangeStart,
+      allUsersRangeEnd: rangeEnd,
       editDialogOpen: false,
       archiveDialogOpen: false,
       selectedUser: null,
@@ -573,12 +585,23 @@ class UsersPage extends React.Component<Props, State> {
     if (this.props.userRole !== 'admin') return
     this.setState({ allUsersLoading: true })
     try {
-      const users = await this.context.getAllUsers()
-      this.setState({ allUsers: users, allUsersLoading: false })
+      const { allUsersRangeStart, allUsersRangeEnd } = this.state
+      const [users, allUsersLoginCounts] = await Promise.all([
+        this.context.getAllUsers(),
+        this.context.getUsersLoginCounts(allUsersRangeStart, allUsersRangeEnd)
+      ])
+      this.setState({ allUsers: users, allUsersLoginCounts, allUsersLoading: false })
     } catch (e) {
       console.error('Error loading all users:', e)
       this.setState({ allUsersLoading: false })
     }
+  }
+
+  handleAllUsersRangeChange = (start: Date, end: Date) => {
+    this.setState({ allUsersRangeStart: start, allUsersRangeEnd: end })
+    this.context.getUsersLoginCounts(start, end)
+      .then(allUsersLoginCounts => this.setState({ allUsersLoginCounts }))
+      .catch(e => console.error('Error loading login counts:', e))
   }
 
   handleAllUserClick = (user: Types.User) => {
@@ -712,6 +735,10 @@ class UsersPage extends React.Component<Props, State> {
                           <div style={{ padding: '30px 30px 40px 30px' }}>
                             <AllUsersTable
                               users={this.state.allUsers}
+                              loginCounts={this.state.allUsersLoginCounts}
+                              rangeStart={this.state.allUsersRangeStart}
+                              rangeEnd={this.state.allUsersRangeEnd}
+                              onRangeChange={this.handleAllUsersRangeChange}
                               onUserClick={this.handleAllUserClick}
                               onArchiveClick={this.handleAllUserArchive}
                             />


### PR DESCRIPTION
## Summary

Promotes the login tracking feature (PR #797) from develop to master for production deployment.

Closes CHALK-115.

## Changes included
- CHALK-110: Backend writes one doc per login to `loginEvents` collection (preserves existing `lastLogin`)
- CHALK-111: `getUsersLoginCounts(start, end)` batch aggregation method
- CHALK-112: Date range picker with 7d / 30d / 90d presets on All Users dashboard
- CHALK-113: New "Login Count" column with date subtitle and numeric sort
- CHALK-114: CSV export includes login count with date-stamped header
- CHALK-115: Wires login counts to the `/LeadersAllUsers` route (UsersPage), header style polish

## QA status
- Type check: 0 errors in src
- Webpack build: clean
- Staging deploy: validated by Ismael May 9
- Header style ("Login Count" + subtitle): approved by Ismael

## Deploy plan
After merge, deploy to production (`cqrefpwa`) via `npm run deploy` — hosting only, no Cloud Functions or Firestore rules changes.

## Historical data caveat
Login counts begin from production deploy date forward. Past logins were never captured as discrete events. Ismael will communicate this to Deanna in the delivery email.