### PR TITLE
fix(usage): defensive try/catch around loginEvents write

### DIFF
--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -322,15 +322,12 @@ class Firebase {
             lastLogin: firebase.firestore.FieldValue.serverTimestamp()
           })
           try {
-            const uid = userCredential.user.uid
-            console.warn('[CHALK-LOGIN-EVENT] about to write, uid=', uid)
-            const ref = await this.db.collection('loginEvents').add({
-              userId: uid,
+            await this.db.collection('loginEvents').add({
+              userId: userCredential.user.uid,
               timestamp: firebase.firestore.FieldValue.serverTimestamp()
             })
-            console.warn('[CHALK-LOGIN-EVENT] write OK, docId=', ref.id)
           } catch (e) {
-            console.error('[CHALK-LOGIN-EVENT] write FAILED:', (e as { code?: string }).code, (e as Error).message, e)
+            console.error('Failed to record loginEvent:', e)
           }
         }
         return userCredential

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -321,10 +321,17 @@ class Firebase {
           await this.db.collection('users').doc(userCredential.user.uid).update({
             lastLogin: firebase.firestore.FieldValue.serverTimestamp()
           })
-          await this.db.collection('loginEvents').add({
-            userId: userCredential.user.uid,
-            timestamp: firebase.firestore.FieldValue.serverTimestamp()
-          })
+          try {
+            const uid = userCredential.user.uid
+            console.warn('[CHALK-LOGIN-EVENT] about to write, uid=', uid)
+            const ref = await this.db.collection('loginEvents').add({
+              userId: uid,
+              timestamp: firebase.firestore.FieldValue.serverTimestamp()
+            })
+            console.warn('[CHALK-LOGIN-EVENT] write OK, docId=', ref.id)
+          } catch (e) {
+            console.error('[CHALK-LOGIN-EVENT] write FAILED:', (e as { code?: string }).code, (e as Error).message, e)
+          }
         }
         return userCredential
       })


### PR DESCRIPTION
## Summary

Wraps the `loginEvents.add()` call in a try/catch so a failed write no longer aborts the user's login flow. Also includes a brief instrumentation cycle that confirmed the original feature works as designed in production.

## Background

After the initial feature deploy, production showed `lastLogin` updating but `loginEvents` collection staying empty. Investigation revealed the cause: **stale Service Worker** serving the pre-feature bundle from precache. The `loginEvents.add()` code never ran for users on cached SWs. Once the SW was unregistered and the user re-logged in, the write succeeded immediately and a fresh doc appeared in the collection.

The defensive try/catch is the production change — it ensures that any future Firestore failure on this collection doesn't break authentication for the user.

Closes CHALK-115.

## Changes
- Wrap `db.collection('loginEvents').add()` in try/catch
- On failure: log `console.error('Failed to record loginEvent:', e)` and continue (login succeeds)
- No behavioral change in the happy path

## Verification
- Confirmed in prod (cqrefpwa): `loginEvents` collection has docs after re-login post SW unregister
- Type check clean