### PR TITLE
chore(release): merge develop into master with login tracking try/catch fix

### DIFF
--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -322,15 +322,12 @@ class Firebase {
             lastLogin: firebase.firestore.FieldValue.serverTimestamp()
           })
           try {
-            const uid = userCredential.user.uid
-            console.warn('[CHALK-LOGIN-EVENT] about to write, uid=', uid)
-            const ref = await this.db.collection('loginEvents').add({
-              userId: uid,
+            await this.db.collection('loginEvents').add({
+              userId: userCredential.user.uid,
               timestamp: firebase.firestore.FieldValue.serverTimestamp()
             })
-            console.warn('[CHALK-LOGIN-EVENT] write OK, docId=', ref.id)
           } catch (e) {
-            console.error('[CHALK-LOGIN-EVENT] write FAILED:', (e as { code?: string }).code, (e as Error).message, e)
+            console.error('Failed to record loginEvent:', e)
           }
         }
         return userCredential

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -321,10 +321,17 @@ class Firebase {
           await this.db.collection('users').doc(userCredential.user.uid).update({
             lastLogin: firebase.firestore.FieldValue.serverTimestamp()
           })
-          await this.db.collection('loginEvents').add({
-            userId: userCredential.user.uid,
-            timestamp: firebase.firestore.FieldValue.serverTimestamp()
-          })
+          try {
+            const uid = userCredential.user.uid
+            console.warn('[CHALK-LOGIN-EVENT] about to write, uid=', uid)
+            const ref = await this.db.collection('loginEvents').add({
+              userId: uid,
+              timestamp: firebase.firestore.FieldValue.serverTimestamp()
+            })
+            console.warn('[CHALK-LOGIN-EVENT] write OK, docId=', ref.id)
+          } catch (e) {
+            console.error('[CHALK-LOGIN-EVENT] write FAILED:', (e as { code?: string }).code, (e as Error).message, e)
+          }
         }
         return userCredential
       })


### PR DESCRIPTION
## Summary

Promotes the defensive try/catch around `loginEvents.add()` from develop to master.

Closes CHALK-115.

## Background

Initial production deploy of the login tracking feature (PR #797 / #798) revealed a Service Worker caching issue — users with stale workbox precache served the pre-feature bundle and the `loginEvents` write never ran. The fix here protects authentication from any future Firestore failure on this collection.

## Changes
- `loginEvents.add()` wrapped in try/catch (Firestore is an external system boundary; failures shouldn't break login)
- On write failure: console.error and continue — login still succeeds visually
- No behavioral change for the happy path

## Already deployed
The corresponding hosting build was already deployed to cqrefpwa (via direct `firebase deploy` from `fix/login-events-debug`) and confirmed working — `loginEvents` collection is accumulating docs as users log in.

This PR is purely to keep `master` in sync with what's running.