### PR TITLE
style(usage): inline date controls with existing filter row

### DIFF
--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -205,6 +205,10 @@ class AllUsersTable extends React.Component<Props, State> {
               <MenuItem value="archived">Archived</MenuItem>
             </Select>
           </FormControl>
+          <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
+            Export
+          </Button>
+          <span style={{ fontSize: 14, fontWeight: 500, color: '#555', marginLeft: 8 }}>Login range:</span>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
             <KeyboardDatePicker
               disableToolbar variant="inline" format="MM/dd/yy" margin="none"
@@ -220,9 +224,6 @@ class AllUsersTable extends React.Component<Props, State> {
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(7)}>Last 7d</Button>
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(30)}>Last 30d</Button>
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(90)}>Last 90d</Button>
-          <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
-            Export
-          </Button>
         </Grid>
 
         <Grid item style={{ overflowX: 'auto' }}>

--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -184,46 +184,50 @@ class AllUsersTable extends React.Component<Props, State> {
 
     return (
       <Grid container direction="column" spacing={2}>
-        <Grid item style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-          <TextField
-            size="small" variant="outlined" label="Search" value={search}
-            onChange={e => this.setState({ search: e.target.value, page: 0 })}
-            style={{ width: 180 }}
-          />
-          <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
-            <InputLabel>Role</InputLabel>
-            <Select value={roleFilter} label="Role" onChange={e => this.setState({ roleFilter: e.target.value as string, page: 0 })}>
-              <MenuItem value=""><em>All</em></MenuItem>
-              {roles.map(r => <MenuItem key={r} value={r}>{this.formatRole(r)}</MenuItem>)}
-            </Select>
-          </FormControl>
-          <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
-            <InputLabel>Status</InputLabel>
-            <Select value={statusFilter} label="Status" onChange={e => this.setState({ statusFilter: e.target.value as string, page: 0 })}>
-              <MenuItem value=""><em>All</em></MenuItem>
-              <MenuItem value="active">Active</MenuItem>
-              <MenuItem value="archived">Archived</MenuItem>
-            </Select>
-          </FormControl>
-          <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
-            Export
-          </Button>
-          <span style={{ fontSize: 14, fontWeight: 500, color: '#555', marginLeft: 8 }}>Login range:</span>
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <KeyboardDatePicker
-              disableToolbar variant="inline" format="MM/dd/yy" margin="none"
-              autoOk label="From" value={rangeStart} style={{ width: 120 }}
-              onChange={(date: Date | null) => date && onRangeChange(date, rangeEnd)}
+        <Grid item style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            <TextField
+              size="small" variant="outlined" label="Search" value={search}
+              onChange={e => this.setState({ search: e.target.value, page: 0 })}
+              style={{ width: 180 }}
             />
-            <KeyboardDatePicker
-              disableToolbar variant="inline" format="MM/dd/yy" margin="none"
-              autoOk label="To" value={rangeEnd} style={{ width: 120 }}
-              onChange={(date: Date | null) => date && onRangeChange(rangeStart, date)}
-            />
-          </MuiPickersUtilsProvider>
-          <Button size="small" variant="outlined" onClick={() => this.applyPreset(7)}>Last 7d</Button>
-          <Button size="small" variant="outlined" onClick={() => this.applyPreset(30)}>Last 30d</Button>
-          <Button size="small" variant="outlined" onClick={() => this.applyPreset(90)}>Last 90d</Button>
+            <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
+              <InputLabel>Role</InputLabel>
+              <Select value={roleFilter} label="Role" onChange={e => this.setState({ roleFilter: e.target.value as string, page: 0 })}>
+                <MenuItem value=""><em>All</em></MenuItem>
+                {roles.map(r => <MenuItem key={r} value={r}>{this.formatRole(r)}</MenuItem>)}
+              </Select>
+            </FormControl>
+            <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
+              <InputLabel>Status</InputLabel>
+              <Select value={statusFilter} label="Status" onChange={e => this.setState({ statusFilter: e.target.value as string, page: 0 })}>
+                <MenuItem value=""><em>All</em></MenuItem>
+                <MenuItem value="active">Active</MenuItem>
+                <MenuItem value="archived">Archived</MenuItem>
+              </Select>
+            </FormControl>
+            <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
+              Export
+            </Button>
+          </div>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            <span style={{ fontSize: 14, fontWeight: 500, color: '#555' }}>Login range:</span>
+            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+              <KeyboardDatePicker
+                disableToolbar variant="inline" format="MM/dd/yy" margin="none"
+                autoOk label="From" value={rangeStart} style={{ width: 120 }}
+                onChange={(date: Date | null) => date && onRangeChange(date, rangeEnd)}
+              />
+              <KeyboardDatePicker
+                disableToolbar variant="inline" format="MM/dd/yy" margin="none"
+                autoOk label="To" value={rangeEnd} style={{ width: 120 }}
+                onChange={(date: Date | null) => date && onRangeChange(rangeStart, date)}
+              />
+            </MuiPickersUtilsProvider>
+            <Button size="small" variant="outlined" onClick={() => this.applyPreset(7)}>Last 7d</Button>
+            <Button size="small" variant="outlined" onClick={() => this.applyPreset(30)}>Last 30d</Button>
+            <Button size="small" variant="outlined" onClick={() => this.applyPreset(90)}>Last 90d</Button>
+          </div>
         </Grid>
 
         <Grid item style={{ overflowX: 'auto' }}>

--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -184,20 +184,20 @@ class AllUsersTable extends React.Component<Props, State> {
 
     return (
       <Grid container direction="column" spacing={2}>
-        <Grid item style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Grid item style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
           <TextField
             size="small" variant="outlined" label="Search" value={search}
             onChange={e => this.setState({ search: e.target.value, page: 0 })}
-            style={{ width: 200 }}
+            style={{ width: 180 }}
           />
-          <FormControl variant="outlined" size="small" style={{ minWidth: 130 }}>
+          <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
             <InputLabel>Role</InputLabel>
             <Select value={roleFilter} label="Role" onChange={e => this.setState({ roleFilter: e.target.value as string, page: 0 })}>
               <MenuItem value=""><em>All</em></MenuItem>
               {roles.map(r => <MenuItem key={r} value={r}>{this.formatRole(r)}</MenuItem>)}
             </Select>
           </FormControl>
-          <FormControl variant="outlined" size="small" style={{ minWidth: 130 }}>
+          <FormControl variant="outlined" size="small" style={{ minWidth: 110 }}>
             <InputLabel>Status</InputLabel>
             <Select value={statusFilter} label="Status" onChange={e => this.setState({ statusFilter: e.target.value as string, page: 0 })}>
               <MenuItem value=""><em>All</em></MenuItem>
@@ -205,28 +205,24 @@ class AllUsersTable extends React.Component<Props, State> {
               <MenuItem value="archived">Archived</MenuItem>
             </Select>
           </FormControl>
-          <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
-            Export
-          </Button>
-        </Grid>
-
-        <Grid item style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-          <span style={{ fontSize: 14, fontWeight: 500, color: '#555' }}>Login range:</span>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
             <KeyboardDatePicker
               disableToolbar variant="inline" format="MM/dd/yy" margin="none"
-              autoOk label="From" value={rangeStart} style={{ width: 150 }}
+              autoOk label="From" value={rangeStart} style={{ width: 120 }}
               onChange={(date: Date | null) => date && onRangeChange(date, rangeEnd)}
             />
             <KeyboardDatePicker
               disableToolbar variant="inline" format="MM/dd/yy" margin="none"
-              autoOk label="To" value={rangeEnd} style={{ width: 150 }}
+              autoOk label="To" value={rangeEnd} style={{ width: 120 }}
               onChange={(date: Date | null) => date && onRangeChange(rangeStart, date)}
             />
           </MuiPickersUtilsProvider>
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(7)}>Last 7d</Button>
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(30)}>Last 30d</Button>
           <Button size="small" variant="outlined" onClick={() => this.applyPreset(90)}>Last 90d</Button>
+          <Button variant="outlined" color="primary" startIcon={<GetAppIcon />} onClick={this.handleExport}>
+            Export
+          </Button>
         </Grid>
 
         <Grid item style={{ overflowX: 'auto' }}>


### PR DESCRIPTION
## Summary

Per Deanna feedback, moves the date-range filter and presets onto the same row as Search/Role/Status/Export instead of a separate row below. Removes the redundant 'Login range:' label since the date pickers already carry From/To labels.

## Changes
- Single Grid item now contains all filter controls
- Slight width reductions on Search and Role/Status to keep everything on one line at common screen widths
- \`flexWrap: wrap\` preserved for narrow viewports
- Behavior unchanged

## Deploy
Already deployed to staging (chalk-dev-c6a5d) for visual validation.