### PR TITLE
feat(usage): replace Last Action with Action Count + shared date filter

### DIFF
--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -4872,6 +4872,124 @@ class Firebase {
     return counts
   }
 
+  getUsersActionCounts = async (
+    startDate: Date,
+    endDate: Date
+  ): Promise<Map<string, {
+    total: number
+    observations: number
+    knowledgeChecks: number
+    conferencePlans: number
+    actionPlans: number
+    emails: number
+  }>> => {
+    type Entry = {
+      total: number
+      observations: number
+      knowledgeChecks: number
+      conferencePlans: number
+      actionPlans: number
+      emails: number
+    }
+    const counts = new Map<string, Entry>()
+
+    const ensure = (userId: string): Entry => {
+      let entry = counts.get(userId)
+      if (!entry) {
+        entry = { total: 0, observations: 0, knowledgeChecks: 0, conferencePlans: 0, actionPlans: 0, emails: 0 }
+        counts.set(userId, entry)
+      }
+      return entry
+    }
+
+    const extractUserId = (ref: string): string => {
+      if (!ref) return ''
+      return ref.startsWith('/user/') ? ref.replace('/user/', '') : ref
+    }
+
+    const inRange = (date: Date | null): boolean => {
+      if (!date) return false
+      return date >= startDate && date <= endDate
+    }
+
+    // Fetch all 5 collections in parallel. observations and knowledgeChecks are
+    // filtered Firestore-side on their single timestamp field. The plan/email
+    // collections have two date fields each (dateCreated + dateModified) and we
+    // want to count the doc if EITHER falls in range, so we fetch all and filter
+    // in memory (these collections are small: ~500/450/440 docs).
+    const [observations, knowledgeChecks, conferencePlans, actionPlans, emails] = await Promise.all([
+      this.db.collection('observations')
+        .where('end', '>=', startDate)
+        .where('end', '<=', endDate)
+        .get(),
+      this.db.collection('knowledgeChecks')
+        .where('timestamp', '>=', startDate)
+        .where('timestamp', '<=', endDate)
+        .get(),
+      this.db.collection('conferencePlans').get(),
+      this.db.collection('actionPlans').get(),
+      this.db.collection('emails').get()
+    ])
+
+    observations.docs.forEach(doc => {
+      const userId = extractUserId(doc.data().teacher)
+      if (!userId) return
+      const entry = ensure(userId)
+      entry.observations++
+      entry.total++
+    })
+
+    knowledgeChecks.docs.forEach(doc => {
+      const userId = doc.data().answeredBy
+      if (!userId) return
+      const entry = ensure(userId)
+      entry.knowledgeChecks++
+      entry.total++
+    })
+
+    conferencePlans.docs.forEach(doc => {
+      const data = doc.data()
+      const userId = data.teacher
+      if (!userId) return
+      const created = data.dateCreated?.toDate?.() || null
+      const modified = data.dateModified?.toDate?.() || null
+      if (inRange(created) || inRange(modified)) {
+        const entry = ensure(userId)
+        entry.conferencePlans++
+        entry.total++
+      }
+    })
+
+    actionPlans.docs.forEach(doc => {
+      const data = doc.data()
+      const userId = data.teacher
+      if (!userId) return
+      const created = data.dateCreated?.toDate?.() || null
+      const modified = data.dateModified?.toDate?.() || null
+      if (inRange(created) || inRange(modified)) {
+        const entry = ensure(userId)
+        entry.actionPlans++
+        entry.total++
+      }
+    })
+
+    // Emails: sender only (recipient receiving an email is not an action they took)
+    emails.docs.forEach(doc => {
+      const data = doc.data()
+      const senderId = data.user
+      if (!senderId) return
+      const created = data.dateCreated?.toDate?.() || null
+      const modified = data.dateModified?.toDate?.() || null
+      if (inRange(created) || inRange(modified)) {
+        const entry = ensure(senderId)
+        entry.emails++
+        entry.total++
+      }
+    })
+
+    return counts
+  }
+
   getAllUsers = async () => {
     const result: Array<{
       id: string
@@ -4882,15 +5000,12 @@ class Firebase {
       program: string
       archived: boolean
       lastLogin: Date | null
-      lastAction: Date | null
-      lastActionType: string
     }> = []
 
-    // Fetch programs, users, and last action data in parallel
-    const [programsSnapshot, usersSnapshot, lastActionMap] = await Promise.all([
+    // Fetch programs and users in parallel
+    const [programsSnapshot, usersSnapshot] = await Promise.all([
       this.db.collection('programs').get(),
-      this.db.collection('users').get(),
-      this.getUsersLastAction()
+      this.db.collection('users').get()
     ])
 
     // Build programs lookup map
@@ -4932,7 +5047,6 @@ class Firebase {
           }
         }
       }
-      const lastActionData = lastActionMap.get(doc.id)
       result.push({
         id: doc.id,
         firstName: data.firstName || '',
@@ -4942,8 +5056,6 @@ class Firebase {
         program: programName,
         archived: data.archived || false,
         lastLogin: data.lastLogin ? data.lastLogin.toDate() : null,
-        lastAction: lastActionData?.date || null,
-        lastActionType: lastActionData?.type || '',
       })
     })
 

--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -43,9 +43,19 @@ const StatusBadge = styled.span<{ archived: boolean }>`
   color: ${props => (props.archived ? '#c62828' : '#2e7d32')};
 `
 
+export type ActionCountEntry = {
+  total: number
+  observations: number
+  knowledgeChecks: number
+  conferencePlans: number
+  actionPlans: number
+  emails: number
+}
+
 interface Props {
   users: Types.User[]
   loginCounts: Map<string, number>
+  actionCounts: Map<string, ActionCountEntry>
   rangeStart: Date
   rangeEnd: Date
   onRangeChange: (start: Date, end: Date) => void
@@ -95,13 +105,17 @@ class AllUsersTable extends React.Component<Props, State> {
     if (statusFilter) users = users.filter(u => u.archived === (statusFilter === 'archived'))
 
     users.sort((a, b) => {
-      const isDateField = sortField === 'lastLogin' || sortField === 'lastAction'
+      const isDateField = sortField === 'lastLogin'
       const isLoginCount = sortField === 'loginCount'
+      const isActionCount = sortField === 'actionCount'
       let aVal: number | string
       let bVal: number | string
       if (isLoginCount) {
         aVal = this.props.loginCounts.get(a.id) || 0
         bVal = this.props.loginCounts.get(b.id) || 0
+      } else if (isActionCount) {
+        aVal = this.props.actionCounts.get(a.id)?.total || 0
+        bVal = this.props.actionCounts.get(b.id)?.total || 0
       } else if (isDateField) {
         aVal = a[sortField]?.getTime() || 0
         bVal = b[sortField]?.getTime() || 0
@@ -122,10 +136,26 @@ class AllUsersTable extends React.Component<Props, State> {
 
   formatDate = (d: Date | null) => d ? d.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' }) : 'Never'
 
-  formatLastAction = (user: Types.User) => {
-    if (!user.lastAction) return 'Never'
-    const date = user.lastAction.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' })
-    return user.lastActionType ? `${user.lastActionType} - ${date}` : date
+  formatActionBreakdown = (entry: ActionCountEntry | undefined): string => {
+    if (!entry || entry.total === 0) return 'No actions in range'
+    const parts: string[] = []
+    if (entry.observations) parts.push(`${entry.observations} observation${entry.observations === 1 ? '' : 's'}`)
+    if (entry.knowledgeChecks) parts.push(`${entry.knowledgeChecks} training${entry.knowledgeChecks === 1 ? '' : 's'}`)
+    if (entry.conferencePlans) parts.push(`${entry.conferencePlans} conference plan${entry.conferencePlans === 1 ? '' : 's'}`)
+    if (entry.actionPlans) parts.push(`${entry.actionPlans} action plan${entry.actionPlans === 1 ? '' : 's'}`)
+    if (entry.emails) parts.push(`${entry.emails} email${entry.emails === 1 ? '' : 's'}`)
+    return parts.join(', ')
+  }
+
+  formatActionBreakdownShort = (entry: ActionCountEntry | undefined): string => {
+    if (!entry || entry.total === 0) return ''
+    const parts: string[] = []
+    if (entry.observations) parts.push(`${entry.observations} obs`)
+    if (entry.knowledgeChecks) parts.push(`${entry.knowledgeChecks} train`)
+    if (entry.conferencePlans) parts.push(`${entry.conferencePlans} conf`)
+    if (entry.actionPlans) parts.push(`${entry.actionPlans} plan`)
+    if (entry.emails) parts.push(`${entry.emails} email`)
+    return parts.join(', ')
   }
 
   formatRangeLabel = () => {
@@ -146,18 +176,24 @@ class AllUsersTable extends React.Component<Props, State> {
     const users = this.getFilteredUsers()
     const headers = [
       'Last Name', 'First Name', 'Email', 'Role', 'Program', 'Status',
-      'Last Login', `Login Count (${this.formatRangeLabel()})`, 'Last Action', 'Action Type'
+      'Last Login',
+      `Login Count (${this.formatRangeLabel()})`,
+      `Action Count (${this.formatRangeLabel()})`,
+      'Action Breakdown'
     ]
     const escape = (val: string) => `"${(val || '').replace(/"/g, '""')}"`
-    const rows = users.map(u => [
-      escape(u.lastName), escape(u.firstName), escape(u.email),
-      escape(this.formatRole(u.role)), escape(u.program || ''),
-      escape(u.archived ? 'Archived' : 'Active'),
-      escape(this.formatDate(u.lastLogin)),
-      String(this.props.loginCounts.get(u.id) || 0),
-      escape(this.formatDate(u.lastAction)),
-      escape(u.lastActionType || '')
-    ].join(','))
+    const rows = users.map(u => {
+      const action = this.props.actionCounts.get(u.id)
+      return [
+        escape(u.lastName), escape(u.firstName), escape(u.email),
+        escape(this.formatRole(u.role)), escape(u.program || ''),
+        escape(u.archived ? 'Archived' : 'Active'),
+        escape(this.formatDate(u.lastLogin)),
+        String(this.props.loginCounts.get(u.id) || 0),
+        String(action?.total || 0),
+        escape(this.formatActionBreakdownShort(action))
+      ].join(',')
+    })
     const csv = [headers.join(','), ...rows].join('\n')
     const blob = new Blob(['\ufeff' + csv], { type: 'text/csv;charset=utf-8;' })
     const link = document.createElement('a')
@@ -211,7 +247,7 @@ class AllUsersTable extends React.Component<Props, State> {
             </Button>
           </div>
           <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-            <span style={{ fontSize: 14, fontWeight: 500, color: '#555' }}>Login range:</span>
+            <span style={{ fontSize: 14, fontWeight: 500, color: '#555' }}>Date range:</span>
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 disableToolbar variant="inline" format="MM/dd/yy" margin="none"
@@ -242,7 +278,7 @@ class AllUsersTable extends React.Component<Props, State> {
                 <SortHeader field="archived" label="Status" />
                 <SortHeader field="lastLogin" label="Last Login" />
                 <SortHeader field="loginCount" label={<span style={{ display: 'inline-flex', flexDirection: 'column', lineHeight: 1.2 }}>Login Count<span style={{ fontSize: '0.75rem', fontWeight: 400, color: '#666' }}>{this.formatRangeLabel()}</span></span>} />
-                <SortHeader field="lastAction" label="Last Action" />
+                <SortHeader field="actionCount" label={<span style={{ display: 'inline-flex', flexDirection: 'column', lineHeight: 1.2 }}>Action Count<span style={{ fontSize: '0.75rem', fontWeight: 400, color: '#666' }}>{this.formatRangeLabel()}</span></span>} />
                 <th style={{ padding: '4px 8px', textAlign: 'center', fontSize: '1.25rem', fontWeight: 500 }}><strong>Edit</strong></th>
               </tr>
             </thead>
@@ -269,7 +305,18 @@ class AllUsersTable extends React.Component<Props, State> {
                   </TableCell>
                   <TableCell>{this.formatDate(user.lastLogin)}</TableCell>
                   <TableCell>{this.props.loginCounts.get(user.id) || 0}</TableCell>
-                  <TableCell>{this.formatLastAction(user)}</TableCell>
+                  <TableCell>
+                    {(() => {
+                      const entry = this.props.actionCounts.get(user.id)
+                      const total = entry?.total || 0
+                      const breakdown = this.formatActionBreakdown(entry)
+                      return (
+                        <Tooltip title={breakdown} placement="top" arrow>
+                          <span style={{ cursor: 'help', borderBottom: total > 0 ? '1px dotted #999' : 'none' }}>{total}</span>
+                        </Tooltip>
+                      )
+                    })()}
+                  </TableCell>
                   <TableCell onClick={e => e.stopPropagation()} style={{ textAlign: 'center' }}>
                     <Tooltip title="Edit user">
                       <IconButton size="small" onClick={() => this.props.onUserClick?.(user)}>

--- a/src/views/protected/AdminViews/AllUsersPage.tsx
+++ b/src/views/protected/AdminViews/AllUsersPage.tsx
@@ -5,7 +5,7 @@ import Firebase, { FirebaseContext } from '../../../components/Firebase'
 import AppBar from '../../../components/AppBar'
 import { connect } from 'react-redux'
 import { Role } from '../../../state/actions/coach'
-import AllUsersTable from '../../../components/UsersComponents/AllUsersTable'
+import AllUsersTable, { ActionCountEntry } from '../../../components/UsersComponents/AllUsersTable'
 import * as Types from '../../../constants/Types'
 
 interface Props { isAdmin: boolean }
@@ -13,6 +13,7 @@ interface State {
   loading: boolean
   users: Types.User[]
   loginCounts: Map<string, number>
+  actionCounts: Map<string, ActionCountEntry>
   rangeStart: Date
   rangeEnd: Date
   editOpen: boolean
@@ -37,7 +38,7 @@ class AllUsersPage extends React.Component<Props, State> {
   context!: Firebase
 
   state: State = {
-    loading: true, users: [], loginCounts: new Map(),
+    loading: true, users: [], loginCounts: new Map(), actionCounts: new Map(),
     rangeStart: defaultRange().start, rangeEnd: defaultRange().end,
     editOpen: false, archiveOpen: false,
     selected: null, firstName: '', lastName: '', email: '',
@@ -47,17 +48,21 @@ class AllUsersPage extends React.Component<Props, State> {
     const { rangeStart, rangeEnd } = this.state
     Promise.all([
       this.context.getAllUsers(),
-      this.context.getUsersLoginCounts(rangeStart, rangeEnd)
+      this.context.getUsersLoginCounts(rangeStart, rangeEnd),
+      this.context.getUsersActionCounts(rangeStart, rangeEnd)
     ])
-      .then(([users, loginCounts]) => this.setState({ users, loginCounts, loading: false }))
+      .then(([users, loginCounts, actionCounts]) => this.setState({ users, loginCounts, actionCounts, loading: false }))
       .catch(() => { alert('Error loading users'); this.setState({ loading: false }) })
   }
 
   handleRangeChange = (start: Date, end: Date) => {
     this.setState({ rangeStart: start, rangeEnd: end })
-    this.context.getUsersLoginCounts(start, end)
-      .then(loginCounts => this.setState({ loginCounts }))
-      .catch(() => alert('Error loading login counts'))
+    Promise.all([
+      this.context.getUsersLoginCounts(start, end),
+      this.context.getUsersActionCounts(start, end)
+    ])
+      .then(([loginCounts, actionCounts]) => this.setState({ loginCounts, actionCounts }))
+      .catch(() => alert('Error loading counts'))
   }
 
   handleUserClick = (user: Types.User) => {
@@ -91,7 +96,7 @@ class AllUsersPage extends React.Component<Props, State> {
 
   render() {
     const { isAdmin } = this.props
-    const { loading, users, loginCounts, rangeStart, rangeEnd, editOpen, archiveOpen, selected, firstName, lastName, email } = this.state
+    const { loading, users, loginCounts, actionCounts, rangeStart, rangeEnd, editOpen, archiveOpen, selected, firstName, lastName, email } = this.state
 
     return (
       <div style={{ height: '100vh', overflow: 'auto' }}>
@@ -112,6 +117,7 @@ class AllUsersPage extends React.Component<Props, State> {
               <AllUsersTable
                 users={users}
                 loginCounts={loginCounts}
+                actionCounts={actionCounts}
                 rangeStart={rangeStart}
                 rangeEnd={rangeEnd}
                 onRangeChange={this.handleRangeChange}

--- a/src/views/protected/UsersViews/UsersPage.tsx
+++ b/src/views/protected/UsersViews/UsersPage.tsx
@@ -18,7 +18,7 @@ import Coaches from "../../../components/UsersComponents/Coaches";
 import Skeleton from "./Skeleton"
 import Archives from "../../../components/UsersComponents/Archives";
 import Sites from "../../../components/UsersComponents/Sites";
-import AllUsersTable from "../../../components/UsersComponents/AllUsersTable";
+import AllUsersTable, { ActionCountEntry } from "../../../components/UsersComponents/AllUsersTable";
 import CHALKLogoGIF from '../../../assets/images/CHALKLogoGIF.gif';
 
 
@@ -114,6 +114,7 @@ interface State {
   allUsers: Types.User[]
   allUsersLoading: boolean
   allUsersLoginCounts: Map<string, number>
+  allUsersActionCounts: Map<string, ActionCountEntry>
   allUsersRangeStart: Date
   allUsersRangeEnd: Date
   editDialogOpen: boolean
@@ -160,6 +161,7 @@ class UsersPage extends React.Component<Props, State> {
       allUsers: [],
       allUsersLoading: true,
       allUsersLoginCounts: new Map(),
+      allUsersActionCounts: new Map(),
       allUsersRangeStart: rangeStart,
       allUsersRangeEnd: rangeEnd,
       editDialogOpen: false,
@@ -586,11 +588,12 @@ class UsersPage extends React.Component<Props, State> {
     this.setState({ allUsersLoading: true })
     try {
       const { allUsersRangeStart, allUsersRangeEnd } = this.state
-      const [users, allUsersLoginCounts] = await Promise.all([
+      const [users, allUsersLoginCounts, allUsersActionCounts] = await Promise.all([
         this.context.getAllUsers(),
-        this.context.getUsersLoginCounts(allUsersRangeStart, allUsersRangeEnd)
+        this.context.getUsersLoginCounts(allUsersRangeStart, allUsersRangeEnd),
+        this.context.getUsersActionCounts(allUsersRangeStart, allUsersRangeEnd)
       ])
-      this.setState({ allUsers: users, allUsersLoginCounts, allUsersLoading: false })
+      this.setState({ allUsers: users, allUsersLoginCounts, allUsersActionCounts, allUsersLoading: false })
     } catch (e) {
       console.error('Error loading all users:', e)
       this.setState({ allUsersLoading: false })
@@ -599,9 +602,12 @@ class UsersPage extends React.Component<Props, State> {
 
   handleAllUsersRangeChange = (start: Date, end: Date) => {
     this.setState({ allUsersRangeStart: start, allUsersRangeEnd: end })
-    this.context.getUsersLoginCounts(start, end)
-      .then(allUsersLoginCounts => this.setState({ allUsersLoginCounts }))
-      .catch(e => console.error('Error loading login counts:', e))
+    Promise.all([
+      this.context.getUsersLoginCounts(start, end),
+      this.context.getUsersActionCounts(start, end)
+    ])
+      .then(([allUsersLoginCounts, allUsersActionCounts]) => this.setState({ allUsersLoginCounts, allUsersActionCounts }))
+      .catch(e => console.error('Error loading counts:', e))
   }
 
   handleAllUserClick = (user: Types.User) => {
@@ -736,6 +742,7 @@ class UsersPage extends React.Component<Props, State> {
                             <AllUsersTable
                               users={this.state.allUsers}
                               loginCounts={this.state.allUsersLoginCounts}
+                              actionCounts={this.state.allUsersActionCounts}
                               rangeStart={this.state.allUsersRangeStart}
                               rangeEnd={this.state.allUsersRangeEnd}
                               onRangeChange={this.handleAllUsersRangeChange}


### PR DESCRIPTION
## Summary

Replaces the "Last Action" column on the All Users dashboard with a new "Action Count" column. The count is computed over the same date range that drives the Login Count — so the existing filter now applies to both. Renames the filter label "Login range" → "Date range".

Closes CHALK-115.

## Changes

### Backend (\`Firebase.tsx\`)
- New \`getUsersActionCounts(start, end)\` — aggregates per-user counts from the same 5 collections that drive Last Action (observations, knowledge checks, conference plans, action plans, emails) within the date range.
- \`getAllUsers\` no longer calls \`getUsersLastAction()\` (the Last Action column was removed). The 29K-doc scan is gone from the dashboard load path.
- \`getUsersLastAction\` method itself is kept in case other consumers exist; not currently used.

### UI (\`AllUsersTable.tsx\`)
- "Last Action" column replaced with "Action Count" — total number, with a tooltip on hover showing the breakdown by type ("3 observations, 5 trainings, 2 conference plans, 1 action plan, 1 email").
- Sort by total count.
- Filter label "Login range:" → "Date range:" (now applies to both counts).

### State (\`AllUsersPage.tsx\`, \`UsersPage.tsx\`)
- Action counts fetched in parallel with login counts on mount and on range change.

### CSV
- New columns: "Action Count (range)" (number) and "Action Breakdown" (text like "3 obs, 5 train").
- Removed: "Last Action", "Action Type".

## Counting strategy
**Option A — per document.** A document is counted once if either its creation or modification timestamp falls in the range. Emails attributed to the sender only (receiving an email is not an action taken). Confirmed with Ismael.

## Performance
- observations + knowledge checks: filtered server-side by timestamp index.
- conference / action plans / emails (~1.5K docs total): fetched in full and filtered in memory due to two-date OR semantics.