### PR TITLE
fix(usage): horizontal scroll on table only

### DIFF
--- a/src/components/UsersComponents/AllUsersTable.tsx
+++ b/src/components/UsersComponents/AllUsersTable.tsx
@@ -276,8 +276,9 @@ class AllUsersTable extends React.Component<Props, State> {
           </div>
         </Grid>
 
-        <Grid item style={{ overflowX: 'auto' }}>
-          <table style={{ borderCollapse: 'collapse', width: '100%', minWidth: 800 }}>
+        <Grid item style={{ width: '100%', maxWidth: '100%', minWidth: 0 }}>
+          <div style={{ overflowX: 'auto', width: '100%' }}>
+          <table style={{ borderCollapse: 'collapse', width: '100%', minWidth: 1200 }}>
             <thead style={{ borderBottom: '2px solid #0988ec' }}>
               <tr>
                 <SortHeader field="lastName" label="Last Name" />
@@ -340,6 +341,7 @@ class AllUsersTable extends React.Component<Props, State> {
               ))}
             </tbody>
           </table>
+          </div>
         </Grid>
 
         <Grid item>


### PR DESCRIPTION
Wraps the table in a div with overflow-x: auto and bumps min-width to 1200px. With 11 columns the table no longer pushes the page sideways; instead the table itself scrolls horizontally. Also explains why Deanna saw Last Action 'missing' — at narrow widths the rightmost columns were clipped off-screen. Closes CHALK-115.