### PR TITLE
feat(v2): CHALK 2.0 renovation preview

### DIFF
--- a/.env-cmdrc.js
+++ b/.env-cmdrc.js
@@ -12,6 +12,7 @@ module.exports = {
   REACT_APP_USE_LOCAL_FIRESTORE: false,
   REACT_APP_USE_LOCAL_FUNCTIONS: false,
   REACT_APP_USE_LOCAL_AUTH: false,
+  REACT_APP_V2_PUBLIC_PREVIEW: false,
   BQ_PROJECT_ID: 'cqrefpwa',
   BQ_DATASET: 'observations'
 },
@@ -28,6 +29,7 @@ module.exports = {
     REACT_APP_USE_LOCAL_FIRESTORE : true,
     REACT_APP_USE_LOCAL_FUNCTIONS: true,
     REACT_APP_USE_LOCAL_AUTH: true,
+    REACT_APP_V2_PUBLIC_PREVIEW: false,
     BQ_PROJECT_ID: 'chalk-dev-c6a5d',
     BQ_DATASET: 'observations_dev'
   },
@@ -43,6 +45,7 @@ module.exports = {
     REACT_APP_USE_LOCAL_FIRESTORE: false,
     REACT_APP_USE_LOCAL_FUNCTIONS: false,
     REACT_APP_USE_LOCAL_AUTH: false,
+    REACT_APP_V2_PUBLIC_PREVIEW: false,
     BQ_PROJECT_ID: 'chalk-dev-c6a5d',
     BQ_DATASET: 'observations',
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,8 @@
 service cloud.firestore {
   match /databases/{database}/documents {
+    // CHALK 2.0 sprint posture: keep the legacy auth-only wildcard for now.
+    // The v2 draft/comment paths inherit this broad rule until Phase 4
+    // security hardening replaces it with document-level ownership checks.
     match /{document=**} {
       allow read, write: if request.auth.uid != null;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,6 +161,28 @@ PrivateRoute.propTypes = {
   render: PropTypes.func
 }
 
+function V2PrivateRoute({ auth, ...rest } : {auth: boolean, [key: string]: any}): React.ReactElement {
+  if (auth) {
+    return <Route {...rest} />
+  }
+
+  return <Route
+    {...rest}
+    render={(props): React.ReactNode => {
+      return (
+        <Redirect to={{ pathname: '/', state: {from: props.location}}} />
+      )
+    }}
+  />
+}
+
+V2PrivateRoute.propTypes = {
+  auth: PropTypes.bool.isRequired,
+  location: PropTypes.object,
+  path: PropTypes.string,
+  render: PropTypes.func
+}
+
 interface Props {
   firebase: Firebase,
   coachLoaded(name: string, role: Role): void,
@@ -280,8 +302,12 @@ class App extends React.Component<Props, State> {
               }
             />
             <Route exact path="/forgot" component={ForgotPasswordPage} />
-            {/* CHALK 2.0 renovation preview — accessible at /v2/* */}
-            <Route path="/v2" render={(): React.ReactElement => <V2App userName={(this.props as { firstName?: string }).firstName || 'Tisha Owen'} />} />
+            {/* CHALK 2.0 renovation preview: public only when the staging flag is enabled. */}
+            {process.env.V2_PUBLIC_PREVIEW ? (
+              <Route path="/v2" render={(): React.ReactElement => <V2App />} />
+            ) : (
+              <V2PrivateRoute auth={auth} path="/v2" render={(): React.ReactElement => <V2App />} />
+            )}
             <PrivateRoute
               auth={auth}
               path="/Landing"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { hot } from 'react-hot-loader/root'
 import * as React from 'react'
 import * as PropTypes from 'prop-types'
 import './App.css'
+import { V2App } from './v2/App'
 import WelcomePage from './views/WelcomeViews/WelcomePage'
 import LoginPage from './views/WelcomeViews/LoginPage'
 import ClassroomClimatePage from './views/protected/ClassroomClimateViews/ClassroomClimatePage'
@@ -279,6 +280,8 @@ class App extends React.Component<Props, State> {
               }
             />
             <Route exact path="/forgot" component={ForgotPasswordPage} />
+            {/* CHALK 2.0 renovation preview — accessible at /v2/* */}
+            <Route path="/v2" render={(): React.ReactElement => <V2App userName={(this.props as { firstName?: string }).firstName || 'Tisha Owen'} />} />
             <PrivateRoute
               auth={auth}
               path="/Landing"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,58 @@ if (module.hot) {
     })
 }
 
+
+function showServiceWorkerUpdateNotice(): void {
+    if (document.getElementById('chalk-update-notice')) {
+        return
+    }
+
+    const notice = document.createElement('div')
+    notice.id = 'chalk-update-notice'
+    notice.setAttribute('role', 'status')
+    notice.style.cssText = [
+        'position: fixed',
+        'right: 20px',
+        'bottom: 20px',
+        'z-index: 10000',
+        'max-width: 360px',
+        'background: #e5f6ff',
+        'color: #006fa5',
+        'border: 1px solid #00b2ff',
+        'border-radius: 8px',
+        'box-shadow: 0 12px 40px rgba(39,39,39,0.12)',
+        'padding: 12px',
+        'font-family: Poppins, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+        'font-size: 13px',
+        'font-weight: 600'
+    ].join(';')
+
+    const copy = document.createElement('div')
+    copy.textContent = 'A new CHALK version is available.'
+    copy.style.marginBottom = '10px'
+
+    const controls = document.createElement('div')
+    controls.style.cssText = 'display:flex; gap:8px; justify-content:flex-end; flex-wrap:wrap'
+
+    const dismiss = document.createElement('button')
+    dismiss.type = 'button'
+    dismiss.textContent = 'Later'
+    dismiss.style.cssText = 'border:1px solid #00b2ff; background:#fff; color:#006fa5; border-radius:999px; padding:6px 12px; font-weight:700; cursor:pointer'
+    dismiss.onclick = () => notice.remove()
+
+    const refresh = document.createElement('button')
+    refresh.type = 'button'
+    refresh.textContent = 'Refresh'
+    refresh.style.cssText = 'border:1px solid #272727; background:#272727; color:#fff; border-radius:999px; padding:6px 12px; font-weight:700; cursor:pointer'
+    refresh.onclick = () => window.location.reload()
+
+    controls.appendChild(dismiss)
+    controls.appendChild(refresh)
+    notice.appendChild(copy)
+    notice.appendChild(controls)
+    document.body.appendChild(notice)
+}
+
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
         let refreshing = false
@@ -62,7 +114,8 @@ if ('serviceWorker' in navigator) {
 
                 installingWorker.onstatechange = () => {
                     if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                        console.log('New CHALK version available; refreshing to activate it.')
+                        console.log('New CHALK version available; waiting for user refresh.')
+                        showServiceWorkerUpdateNotice()
                     }
                 }
             }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,8 +42,30 @@ if (module.hot) {
 
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
+        let refreshing = false
+
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+            if (refreshing) {
+                return
+            }
+            refreshing = true
+            window.location.reload()
+        })
+
         navigator.serviceWorker.register('/service-worker.js').then(registration => {
             console.log('SW registered: ', registration)
+            registration.onupdatefound = () => {
+                const installingWorker = registration.installing
+                if (!installingWorker) {
+                    return
+                }
+
+                installingWorker.onstatechange = () => {
+                    if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                        console.log('New CHALK version available; refreshing to activate it.')
+                    }
+                }
+            }
         }).catch(registrationError => {
             console.log('SW registration failed: ', registrationError)
         })

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { Route, Switch, Redirect, useHistory } from 'react-router-dom'
+import { AppShell } from './layout/AppShell'
+import { CoachHome } from './pages/CoachHome'
+import { PlaceholderPage } from './pages/PlaceholderPage'
+import { useTheme } from './hooks/useTheme'
+
+import './design/tokens.css'
+import './design/globals.css'
+
+/**
+ * v2 App entry point. Mounted under /v2/* by the main App router.
+ * Everything inside .v2-root is scoped — no leakage to legacy MUI styling.
+ */
+export function V2App(props: { userName?: string }) {
+  // Touch the hook so the theme attribute syncs even before any child mounts
+  useTheme()
+  const history = useHistory()
+  const userName = props.userName ?? 'Coach'
+
+  const path = history.location.pathname
+  const activeKey =
+    path.startsWith('/v2/teachers') ? 'teachers' :
+    path.startsWith('/v2/observation') ? 'observation' :
+    path.startsWith('/v2/plans') ? 'plans' :
+    path.startsWith('/v2/training') ? 'training' :
+    'home'
+
+  return (
+    <div className="v2-root" data-theme="light">
+      <AppShell
+        activeKey={activeKey}
+        user={{ name: userName }}
+        onNavigate={(to) => history.push(to)}
+      >
+        <Switch>
+          <Route path="/v2/home" render={() => <CoachHome userName={userName} />} />
+          <Route path="/v2/teachers" render={() => <PlaceholderPage title="All Teachers" subtitle="Will replace the current /LeadersAllUsers view with the v2 design, keeping the login/action count infrastructure already in place." />} />
+          <Route path="/v2/observation" render={() => <PlaceholderPage title="Live Observation — Open Mode" subtitle="The new free-form note-taking experience with post-session alignment to Magic 9." />} />
+          <Route path="/v2/plans" render={() => <PlaceholderPage title="Plans — Auto-save & Share" subtitle="Coaching & action plans with auto-save, send-to-teacher, threaded comments." />} />
+          <Route path="/v2/training" render={() => <PlaceholderPage title="Adaptive Training" subtitle="Recommendations driven by your observation data — not blanket gates." />} />
+          <Redirect to="/v2/home" />
+        </Switch>
+      </AppShell>
+    </div>
+  )
+}
+
+export default V2App

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import { Route, Switch, Redirect, useHistory } from 'react-router-dom'
 import { AppShell } from './layout/AppShell'
 import { CoachHome } from './pages/CoachHome'
-import { PlaceholderPage } from './pages/PlaceholderPage'
+import { AllTeachers } from './pages/AllTeachers'
+import { LiveObservation } from './pages/LiveObservation'
+import { PlanDetail } from './pages/PlanDetail'
+import { Training } from './pages/Training'
 import { useTheme } from './hooks/useTheme'
 
 import './design/tokens.css'
@@ -35,10 +38,10 @@ export function V2App(props: { userName?: string }) {
       >
         <Switch>
           <Route path="/v2/home" render={() => <CoachHome userName={userName} />} />
-          <Route path="/v2/teachers" render={() => <PlaceholderPage title="All Teachers" subtitle="Will replace the current /LeadersAllUsers view with the v2 design, keeping the login/action count infrastructure already in place." />} />
-          <Route path="/v2/observation" render={() => <PlaceholderPage title="Live Observation — Open Mode" subtitle="The new free-form note-taking experience with post-session alignment to Magic 9." />} />
-          <Route path="/v2/plans" render={() => <PlaceholderPage title="Plans — Auto-save & Share" subtitle="Coaching & action plans with auto-save, send-to-teacher, threaded comments." />} />
-          <Route path="/v2/training" render={() => <PlaceholderPage title="Adaptive Training" subtitle="Recommendations driven by your observation data — not blanket gates." />} />
+          <Route path="/v2/teachers" render={() => <AllTeachers />} />
+          <Route path="/v2/observation" render={() => <LiveObservation />} />
+          <Route path="/v2/plans" render={() => <PlanDetail />} />
+          <Route path="/v2/training" render={() => <Training />} />
           <Redirect to="/v2/home" />
         </Switch>
       </AppShell>

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -6,20 +6,24 @@ import { AllTeachers } from './pages/AllTeachers'
 import { LiveObservation } from './pages/LiveObservation'
 import { PlanDetail } from './pages/PlanDetail'
 import { Training } from './pages/Training'
+import { ErrorBoundary } from './components/ErrorBoundary'
+import { EmptyState } from './components/EmptyState'
+import { Toast } from './components/Toast'
 import { useTheme } from './hooks/useTheme'
+import { useV2Auth } from './hooks/useV2Auth'
+import { ToastProvider } from './hooks/useToast'
+import { V2FirebaseProvider } from './lib/firebase'
 
 import './design/tokens.css'
 import './design/globals.css'
 
-/**
- * v2 App entry point. Mounted under /v2/* by the main App router.
- * Everything inside .v2-root is scoped — no leakage to legacy MUI styling.
- */
-export function V2App(props: { userName?: string }) {
-  // Touch the hook so the theme attribute syncs even before any child mounts
-  useTheme()
+function V2Routes() {
   const history = useHistory()
-  const userName = props.userName ?? 'Coach'
+  const auth = useV2Auth()
+
+  const userName = auth.user
+    ? `${auth.user.firstName} ${auth.user.lastName}`.trim() || 'Coach'
+    : 'Coach'
 
   const path = history.location.pathname
   const activeKey =
@@ -30,21 +34,46 @@ export function V2App(props: { userName?: string }) {
     'home'
 
   return (
-    <div className="v2-root" data-theme="light">
+    <ToastProvider>
       <AppShell
         activeKey={activeKey}
-        user={{ name: userName }}
+        user={{ name: auth.loading ? 'Coach' : userName, role: auth.user?.role }}
         onNavigate={(to) => history.push(to)}
       >
-        <Switch>
-          <Route path="/v2/home" render={() => <CoachHome userName={userName} />} />
-          <Route path="/v2/teachers" render={() => <AllTeachers />} />
-          <Route path="/v2/observation" render={() => <LiveObservation />} />
-          <Route path="/v2/plans" render={() => <PlanDetail />} />
-          <Route path="/v2/training" render={() => <Training />} />
-          <Redirect to="/v2/home" />
-        </Switch>
+        <ErrorBoundary fallback={(
+          <EmptyState
+            title="Unable to load this view"
+            description="Refresh the page or return to the CHALK home screen."
+          />
+        )}>
+          <Switch>
+            <Route path="/v2/home" render={() => <CoachHome userName={userName} />} />
+            <Route path="/v2/teachers" render={() => <AllTeachers />} />
+            <Route path="/v2/observation" render={() => <LiveObservation />} />
+            <Route path="/v2/plans/:planId?" render={() => <PlanDetail />} />
+            <Route path="/v2/training" render={() => <Training />} />
+            <Redirect to="/v2/home" />
+          </Switch>
+        </ErrorBoundary>
       </AppShell>
+      <Toast />
+    </ToastProvider>
+  )
+}
+
+/**
+ * v2 App entry point. Mounted under /v2/* by the main App router.
+ * Everything inside .v2-root is scoped; no leakage to legacy MUI styling.
+ */
+export function V2App() {
+  // Touch the hook so the theme attribute syncs even before any child mounts.
+  useTheme()
+
+  return (
+    <div className="v2-root" data-theme="light">
+      <V2FirebaseProvider>
+        <V2Routes />
+      </V2FirebaseProvider>
     </div>
   )
 }

--- a/src/v2/components/Avatar.tsx
+++ b/src/v2/components/Avatar.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #f0523d, #d63a26)',  // warm
+  'linear-gradient(135deg, #00b2ff, #0091d4)',  // brand
+  'linear-gradient(135deg, #f0a623, #ea7c1e)',  // gold
+  'linear-gradient(135deg, #6f39c4, #f0523d)',  // purple-warm
+  'linear-gradient(135deg, #2ECC71, #00b2ff)',  // success-brand
+  'linear-gradient(135deg, #00b2ff, #f0a623)',  // brand-gold
+]
+
+function hashIndex(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
+  return Math.abs(h) % GRADIENTS.length
+}
+
+function initialsFromName(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(p => p[0]?.toUpperCase() || '')
+    .join('')
+}
+
+export function Avatar(props: { name?: string; initials?: string; size?: number; seed?: string }) {
+  const initials = props.initials ?? (props.name ? initialsFromName(props.name) : '?')
+  const seed = props.seed ?? props.name ?? initials
+  const size = props.size ?? 36
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: GRADIENTS[hashIndex(seed)],
+        color: '#fff',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 700,
+        fontSize: size * 0.38,
+        flexShrink: 0,
+        userSelect: 'none'
+      }}
+    >
+      {initials}
+    </div>
+  )
+}

--- a/src/v2/components/Button.tsx
+++ b/src/v2/components/Button.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+
+export type ButtonProps = {
+  variant?: 'default' | 'primary' | 'accent' | 'warm' | 'ghost'
+  size?: 'sm' | 'md'
+  icon?: React.ReactNode
+  children?: React.ReactNode
+  onClick?: (e: React.MouseEvent) => void
+  disabled?: boolean
+  type?: 'button' | 'submit'
+  style?: React.CSSProperties
+  className?: string
+  title?: string
+}
+
+const styles: { [k: string]: React.CSSProperties } = {
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.4rem',
+    fontFamily: 'var(--v2-font)',
+    fontWeight: 600,
+    borderRadius: 'var(--v2-radius-pill)',
+    border: '1px solid transparent',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+    whiteSpace: 'nowrap'
+  },
+  md: { fontSize: '0.88rem', padding: '0.55rem 1.1rem' },
+  sm: { fontSize: '0.78rem', padding: '0.4rem 0.85rem' },
+  default: { background: 'var(--v2-white)', color: 'var(--v2-ink-soft)', borderColor: 'var(--v2-line)' },
+  primary: { background: 'var(--v2-ink)', color: 'var(--v2-white)', borderColor: 'var(--v2-ink)' },
+  accent: { background: 'var(--v2-brand)', color: 'var(--v2-white)', borderColor: 'var(--v2-brand)' },
+  warm: { background: 'var(--v2-warm)', color: 'var(--v2-white)', borderColor: 'var(--v2-warm)' },
+  ghost: { background: 'transparent', color: 'var(--v2-ink-soft)', borderColor: 'transparent' }
+}
+
+export function Button(p: ButtonProps) {
+  const { variant = 'default', size = 'md', icon, children, ...rest } = p
+  const combined: React.CSSProperties = {
+    ...styles.base,
+    ...(size === 'sm' ? styles.sm : styles.md),
+    ...styles[variant],
+    ...(p.style || {})
+  }
+  return (
+    <button
+      type={rest.type || 'button'}
+      onClick={rest.onClick}
+      disabled={rest.disabled}
+      style={combined}
+      className={rest.className}
+      title={rest.title}
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}

--- a/src/v2/components/Card.tsx
+++ b/src/v2/components/Card.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+export function Card(props: { children: React.ReactNode; style?: React.CSSProperties; padding?: string }) {
+  return (
+    <div
+      style={{
+        background: 'var(--v2-white)',
+        borderRadius: 'var(--v2-radius)',
+        padding: props.padding ?? '1.35rem',
+        border: '1px solid var(--v2-line-soft)',
+        boxShadow: 'var(--v2-shadow-sm)',
+        ...(props.style || {})
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+export function CardHeader(props: { title: React.ReactNode; action?: React.ReactNode; badge?: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.1rem' }}>
+      <div style={{ fontSize: '0.95rem', fontWeight: 600, letterSpacing: '-0.01em', display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+        {props.title}
+        {props.badge}
+      </div>
+      {props.action && (
+        <div style={{ fontSize: '0.8rem', color: 'var(--v2-brand-dark)', fontWeight: 600, cursor: 'pointer' }}>
+          {props.action}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/v2/components/EmptyState.tsx
+++ b/src/v2/components/EmptyState.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+export function EmptyState(props: { icon?: React.ReactNode; title: string; description: string; cta?: React.ReactNode }) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: 220,
+      textAlign: 'center',
+      padding: '2rem',
+      color: 'var(--v2-muted)'
+    }}>
+      {props.icon && <div style={{ fontSize: '2rem', marginBottom: '0.8rem' }}>{props.icon}</div>}
+      <h3 style={{ color: 'var(--v2-ink)', fontSize: '1rem', marginBottom: '0.35rem' }}>{props.title}</h3>
+      <p style={{ maxWidth: 420, fontSize: '0.88rem', lineHeight: 1.55 }}>{props.description}</p>
+      {props.cta && <div style={{ marginTop: '1rem' }}>{props.cta}</div>}
+    </div>
+  )
+}

--- a/src/v2/components/ErrorBoundary.tsx
+++ b/src/v2/components/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+type State = { hasError: boolean }
+
+export class ErrorBoundary extends React.Component<{ children: React.ReactNode; fallback?: React.ReactNode }, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('CHALK 2.0 render error', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || (
+        <div style={{ padding: '2rem', color: 'var(--v2-warm-dark)' }}>
+          Something went wrong loading this CHALK 2.0 view.
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/v2/components/Pill.tsx
+++ b/src/v2/components/Pill.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+export type PillVariant = 'neutral' | 'warn' | 'danger' | 'success' | 'brand'
+
+const map: Record<PillVariant, { bg: string; fg: string }> = {
+  neutral: { bg: 'var(--v2-bg-soft)', fg: 'var(--v2-muted)' },
+  warn:    { bg: 'var(--v2-gold-soft)', fg: '#B45309' },
+  danger:  { bg: 'var(--v2-danger-soft)', fg: 'var(--v2-danger)' },
+  success: { bg: 'var(--v2-success-soft)', fg: '#166534' },
+  brand:   { bg: 'var(--v2-brand-soft)', fg: 'var(--v2-brand-darker)' }
+}
+
+export function Pill(props: { variant?: PillVariant; children: React.ReactNode; style?: React.CSSProperties }) {
+  const v = props.variant ?? 'neutral'
+  const c = map[v]
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.1rem 0.5rem',
+        borderRadius: 4,
+        fontSize: '0.7rem',
+        fontWeight: 600,
+        background: c.bg,
+        color: c.fg,
+        ...(props.style || {})
+      }}
+    >
+      {props.children}
+    </span>
+  )
+}

--- a/src/v2/components/Skeleton.tsx
+++ b/src/v2/components/Skeleton.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+
+export function Skeleton(props: { width?: number | string; height?: number | string; style?: React.CSSProperties }) {
+  return (
+    <span
+      className="v2-skeleton"
+      style={{
+        display: 'inline-block',
+        width: props.width ?? '100%',
+        height: props.height ?? 16,
+        borderRadius: 6,
+        ...(props.style || {})
+      }}
+    />
+  )
+}
+
+export function TableSkeleton(props: { rows?: number; cols?: number }) {
+  const rows = Array.from({ length: props.rows ?? 6 })
+  const cols = Array.from({ length: props.cols ?? 5 })
+  return (
+    <div style={{ display: 'grid', gap: '0.75rem' }}>
+      {rows.map((_, rowIndex) => (
+        <div key={rowIndex} style={{ display: 'grid', gridTemplateColumns: `repeat(${cols.length}, 1fr)`, gap: '0.75rem', alignItems: 'center' }}>
+          {cols.map((__, colIndex) => (
+            <Skeleton key={colIndex} height={colIndex === 0 ? 28 : 18} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function StatSkeleton() {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
+      {[0, 1, 2, 3].map(index => (
+        <div key={index} style={{ background: 'var(--v2-white)', border: '1px solid var(--v2-line-soft)', borderRadius: 'var(--v2-radius)', padding: '1rem' }}>
+          <Skeleton width={42} height={42} style={{ marginBottom: '0.85rem' }} />
+          <Skeleton width="60%" height={14} style={{ marginBottom: '0.65rem' }} />
+          <Skeleton width="35%" height={28} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/v2/components/Skeleton.tsx
+++ b/src/v2/components/Skeleton.tsx
@@ -33,7 +33,7 @@ export function TableSkeleton(props: { rows?: number; cols?: number }) {
 
 export function StatSkeleton() {
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: '1rem', marginBottom: '1.5rem' }}>
       {[0, 1, 2, 3].map(index => (
         <div key={index} style={{ background: 'var(--v2-white)', border: '1px solid var(--v2-line-soft)', borderRadius: 'var(--v2-radius)', padding: '1rem' }}>
           <Skeleton width={42} height={42} style={{ marginBottom: '0.85rem' }} />

--- a/src/v2/components/Stat.tsx
+++ b/src/v2/components/Stat.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+
+export type StatTone = 'brand' | 'warm' | 'gold' | 'success'
+
+const iconBg: Record<StatTone, { bg: string; fg: string }> = {
+  brand:   { bg: 'var(--v2-brand-soft)', fg: 'var(--v2-brand-dark)' },
+  warm:    { bg: 'var(--v2-warm-soft)', fg: 'var(--v2-warm)' },
+  gold:    { bg: 'var(--v2-gold-soft)', fg: 'var(--v2-gold)' },
+  success: { bg: 'var(--v2-success-soft)', fg: 'var(--v2-success)' }
+}
+
+const deltaColor: Record<'up'|'warn'|'flat', string> = {
+  up: 'var(--v2-success)',
+  warn: 'var(--v2-warm)',
+  flat: 'var(--v2-muted)'
+}
+
+export function Stat(props: {
+  label: string
+  value: React.ReactNode
+  icon?: React.ReactNode
+  tone?: StatTone
+  delta?: { text: string; trend: 'up' | 'warn' | 'flat' }
+}) {
+  const tone = props.tone ?? 'brand'
+  return (
+    <div style={{
+      background: 'var(--v2-white)',
+      borderRadius: 'var(--v2-radius)',
+      padding: '1.2rem 1.35rem',
+      border: '1px solid var(--v2-line-soft)',
+      position: 'relative',
+      boxShadow: 'var(--v2-shadow-sm)'
+    }}>
+      {props.icon && (
+        <div style={{
+          position: 'absolute',
+          top: '1rem', right: '1rem',
+          width: 36, height: 36,
+          borderRadius: 9,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: '1.05rem',
+          background: iconBg[tone].bg,
+          color: iconBg[tone].fg
+        }}>
+          {props.icon}
+        </div>
+      )}
+      <div style={{
+        fontSize: '0.7rem', fontWeight: 600,
+        color: 'var(--v2-muted)',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase'
+      }}>
+        {props.label}
+      </div>
+      <div style={{
+        fontSize: '2rem', fontWeight: 700,
+        letterSpacing: '-0.03em',
+        margin: '0.35rem 0 0.15rem',
+        color: 'var(--v2-ink)'
+      }}>
+        {props.value}
+      </div>
+      {props.delta && (
+        <div style={{ fontSize: '0.78rem', fontWeight: 600, color: deltaColor[props.delta.trend] }}>
+          {props.delta.text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/v2/components/Toast.tsx
+++ b/src/v2/components/Toast.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { ToastTone, useToastItems } from '../hooks/useToast'
+
+const toneStyle: Record<ToastTone, { background: string; color: string; border: string }> = {
+  success: { background: 'var(--v2-success-soft)', color: 'var(--v2-success)', border: 'var(--v2-success)' },
+  error: { background: 'var(--v2-warm-soft)', color: 'var(--v2-warm-dark)', border: 'var(--v2-warm)' },
+  info: { background: 'var(--v2-brand-soft)', color: 'var(--v2-brand-darker)', border: 'var(--v2-brand)' }
+}
+
+export function Toast() {
+  const { items, dismiss } = useToastItems()
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div style={{ position: 'fixed', right: 20, bottom: 20, zIndex: 1000, display: 'grid', gap: '0.65rem', maxWidth: 360 }}>
+      {items.map(item => {
+        const tone = toneStyle[item.tone]
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => dismiss(item.id)}
+            style={{
+              textAlign: 'left',
+              background: tone.background,
+              color: tone.color,
+              border: `1px solid ${tone.border}`,
+              borderRadius: 8,
+              padding: '0.8rem 0.95rem',
+              boxShadow: 'var(--v2-shadow-md)',
+              fontWeight: 600,
+              fontSize: '0.84rem'
+            }}
+          >
+            {item.message}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/v2/design/globals.css
+++ b/src/v2/design/globals.css
@@ -72,3 +72,14 @@
     animation: none;
   }
 }
+
+
+@media (max-width: 720px) {
+  .v2-root .v2-page {
+    padding: 1rem !important;
+  }
+
+  .v2-root table {
+    font-size: 0.82rem;
+  }
+}

--- a/src/v2/design/globals.css
+++ b/src/v2/design/globals.css
@@ -1,0 +1,56 @@
+/* ============================================================
+   CHALK 2.0 — Global resets, scoped to .v2-root
+   ============================================================
+   Reset only inside the v2 tree so legacy MUI styling stays
+   untouched. Loads Poppins from Google Fonts.
+============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap');
+
+.v2-root,
+.v2-root *,
+.v2-root *::before,
+.v2-root *::after {
+  box-sizing: border-box;
+}
+
+.v2-root {
+  font-family: var(--v2-font);
+  color: var(--v2-ink);
+  background: var(--v2-bg);
+  line-height: 1.5;
+  font-size: 14.5px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+}
+
+.v2-root a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.v2-root button {
+  font-family: var(--v2-font);
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: inherit;
+}
+
+.v2-root input,
+.v2-root select,
+.v2-root textarea {
+  font-family: var(--v2-font);
+  font-size: 0.95rem;
+  color: var(--v2-ink);
+}
+
+.v2-root h1, .v2-root h2, .v2-root h3, .v2-root h4 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.v2-root p { margin: 0; }
+.v2-root ul, .v2-root ol { margin: 0; padding: 0; list-style: none; }

--- a/src/v2/design/globals.css
+++ b/src/v2/design/globals.css
@@ -54,3 +54,21 @@
 
 .v2-root p { margin: 0; }
 .v2-root ul, .v2-root ol { margin: 0; padding: 0; list-style: none; }
+
+
+.v2-root .v2-skeleton {
+  background: linear-gradient(90deg, var(--v2-bg-soft), var(--v2-line-soft), var(--v2-bg-soft));
+  background-size: 220% 100%;
+  animation: v2-skeleton-pulse 1.25s ease-in-out infinite;
+}
+
+@keyframes v2-skeleton-pulse {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-root .v2-skeleton {
+    animation: none;
+  }
+}

--- a/src/v2/design/tokens.css
+++ b/src/v2/design/tokens.css
@@ -1,0 +1,95 @@
+/* ============================================================
+   CHALK 2.0 — Design tokens
+   ============================================================
+   All visual constants of the renovated app live here as CSS
+   custom properties. Light and dark themes share the same names;
+   only the values differ. This makes theme switching instant.
+
+   Scoped to .v2-root so it never leaks to legacy MUI code.
+============================================================ */
+
+.v2-root {
+  /* Brand (matches chalkcoaching.com) */
+  --v2-brand: #00b2ff;
+  --v2-brand-dark: #0091d4;
+  --v2-brand-darker: #006fa5;
+  --v2-brand-soft: #E5F6FF;
+  --v2-brand-softer: #F2FAFF;
+
+  --v2-warm: #f0523d;
+  --v2-warm-dark: #d63a26;
+  --v2-warm-soft: #FFE9E4;
+
+  --v2-gold: #f0a623;
+  --v2-gold-soft: #FCEFD8;
+
+  /* Neutrals */
+  --v2-ink: #272727;
+  --v2-ink-soft: #3e3e3e;
+  --v2-muted: #6B6B6B;
+  --v2-muted-soft: #9b9b9b;
+  --v2-line: #E4E4E4;
+  --v2-line-soft: #f0f0f0;
+  --v2-bg: #fafafa;
+  --v2-bg-soft: #f6f6f6;
+  --v2-white: #ffffff;
+
+  /* Semantic */
+  --v2-success: #2ECC71;
+  --v2-success-soft: #DCF7E8;
+  --v2-danger: #EF4444;
+  --v2-danger-soft: #FFE5E5;
+
+  /* Radii */
+  --v2-radius-sm: 8px;
+  --v2-radius: 12px;
+  --v2-radius-lg: 16px;
+  --v2-radius-xl: 20px;
+  --v2-radius-pill: 999px;
+
+  /* Shadows */
+  --v2-shadow-sm: 0 1px 3px rgba(39, 39, 39, 0.05);
+  --v2-shadow: 0 4px 16px rgba(39, 39, 39, 0.06);
+  --v2-shadow-lg: 0 12px 40px rgba(39, 39, 39, 0.10);
+
+  /* Typography */
+  --v2-font: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  /* Spacing scale (4px base) */
+  --v2-sp-1: 4px;
+  --v2-sp-2: 8px;
+  --v2-sp-3: 12px;
+  --v2-sp-4: 16px;
+  --v2-sp-5: 20px;
+  --v2-sp-6: 24px;
+  --v2-sp-8: 32px;
+  --v2-sp-10: 40px;
+  --v2-sp-12: 48px;
+
+  /* Z-index */
+  --v2-z-dropdown: 100;
+  --v2-z-sticky: 200;
+  --v2-z-modal: 1000;
+  --v2-z-toast: 2000;
+}
+
+.v2-root[data-theme="dark"] {
+  --v2-bg: #0F1419;
+  --v2-bg-soft: #1A1F26;
+  --v2-white: #1F2630;
+  --v2-ink: #E5E7EB;
+  --v2-ink-soft: #B8BCC2;
+  --v2-muted: #9CA3AF;
+  --v2-muted-soft: #6B7280;
+  --v2-line: #2D3340;
+  --v2-line-soft: #242931;
+  --v2-brand-soft: #003D5E;
+  --v2-brand-softer: #002940;
+  --v2-warm-soft: #3D1F18;
+  --v2-gold-soft: #3D2F12;
+  --v2-success-soft: #0F3B26;
+  --v2-danger-soft: #3D1A1A;
+  --v2-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --v2-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --v2-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.6);
+}

--- a/src/v2/hooks/useTheme.ts
+++ b/src/v2/hooks/useTheme.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState, useCallback } from 'react'
+
+type Theme = 'light' | 'dark'
+const STORAGE_KEY = 'chalk-v2-theme'
+
+function readSaved(): Theme {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'dark' || v === 'light') return v
+  } catch (e) { /* localStorage may not be available */ }
+  return 'light'
+}
+
+/**
+ * Theme hook. Default is light. Persists to localStorage.
+ * No system-preference fallback by design — the team chose light as default.
+ */
+export function useTheme(rootRef?: HTMLElement | null) {
+  const [theme, setTheme] = useState<Theme>(readSaved)
+
+  useEffect(() => {
+    const el = rootRef ?? document.documentElement.querySelector<HTMLElement>('.v2-root')
+    if (el) el.setAttribute('data-theme', theme)
+    try { localStorage.setItem(STORAGE_KEY, theme) } catch (e) { /* ignore */ }
+  }, [theme, rootRef])
+
+  const toggle = useCallback(() => {
+    setTheme(t => t === 'light' ? 'dark' : 'light')
+  }, [])
+
+  return { theme, setTheme, toggle }
+}

--- a/src/v2/hooks/useToast.ts
+++ b/src/v2/hooks/useToast.ts
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+export type ToastTone = 'success' | 'error' | 'info'
+
+export type ToastItem = {
+  id: number
+  tone: ToastTone
+  message: string
+}
+
+type ToastContextValue = {
+  items: ToastItem[]
+  success(message: string): void
+  error(message: string): void
+  info(message: string): void
+  dismiss(id: number): void
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null)
+
+export function ToastProvider(props: { children: React.ReactNode }) {
+  const [items, setItems] = React.useState<ToastItem[]>([])
+
+  const dismiss = React.useCallback((id: number) => {
+    setItems(current => current.filter(item => item.id !== id))
+  }, [])
+
+  const push = React.useCallback((tone: ToastTone, message: string) => {
+    const id = Date.now() + Math.round(Math.random() * 1000)
+    setItems(current => [...current, { id, tone, message }])
+    window.setTimeout(() => dismiss(id), 3500)
+  }, [dismiss])
+
+  const value = React.useMemo(() => ({
+    items,
+    success: (message: string) => push('success', message),
+    error: (message: string) => push('error', message),
+    info: (message: string) => push('info', message),
+    dismiss
+  }), [dismiss, items, push])
+
+  return React.createElement(ToastContext.Provider, { value }, props.children)
+}
+
+export function useToast() {
+  const context = React.useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used inside ToastProvider')
+  }
+  return context
+}
+
+export function useToastItems() {
+  return useToast()
+}

--- a/src/v2/hooks/useV2Auth.ts
+++ b/src/v2/hooks/useV2Auth.ts
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { useV2Firebase } from '../lib/firebase'
+import { V2User } from '../lib/types'
+
+type AuthState = {
+  user: V2User | null
+  loading: boolean
+  error: Error | null
+}
+
+export function useV2Auth(): AuthState {
+  const firebase = useV2Firebase()
+  const [state, setState] = React.useState<AuthState>({
+    user: null,
+    loading: true,
+    error: null
+  })
+
+  React.useEffect(() => {
+    let active = true
+
+    const unsubscribe = firebase.auth.onAuthStateChanged(async authUser => {
+      if (!active) {
+        return
+      }
+
+      if (!authUser) {
+        setState({ user: null, loading: false, error: null })
+        return
+      }
+
+      setState(current => ({ ...current, loading: true, error: null }))
+
+      try {
+        const userDoc: any = await firebase.getUserInformation()
+        if (!active) {
+          return
+        }
+
+        setState({
+          user: {
+            uid: authUser.uid,
+            email: authUser.email || userDoc?.email || '',
+            isAnonymous: authUser.isAnonymous,
+            firstName: userDoc?.firstName || 'Coach',
+            lastName: userDoc?.lastName || '',
+            role: userDoc?.role || '',
+            programs: userDoc?.programs || (userDoc?.program ? [userDoc.program] : undefined),
+            sites: userDoc?.sites
+          },
+          loading: false,
+          error: null
+        })
+      } catch (error) {
+        if (!active) {
+          return
+        }
+        setState({ user: null, loading: false, error: error as Error })
+      }
+    })
+
+    return () => {
+      active = false
+      unsubscribe()
+    }
+  }, [firebase])
+
+  return state
+}

--- a/src/v2/layout/AppShell.tsx
+++ b/src/v2/layout/AppShell.tsx
@@ -30,7 +30,9 @@ export function AppShell(props: {
         zIndex: 100,
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between'
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        gap: '0.75rem'
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem', fontWeight: 700, fontSize: '1.1rem', letterSpacing: '-0.01em' }}>
           <div style={{
@@ -58,9 +60,9 @@ export function AppShell(props: {
         <div style={{
           display: 'flex',
           gap: '0.25rem',
-          position: 'absolute',
-          left: '50%',
-          transform: 'translateX(-50%)'
+          flex: '1 1 460px',
+          justifyContent: 'center',
+          flexWrap: 'wrap'
         }}>
           {NAV_ITEMS.map(item => {
             const active = item.key === props.activeKey
@@ -85,7 +87,7 @@ export function AppShell(props: {
                 {active && (
                   <span style={{
                     position: 'absolute',
-                    bottom: '-0.95rem',
+                    bottom: '-0.6rem',
                     left: '1rem', right: '1rem',
                     height: 2,
                     background: 'var(--v2-brand)',

--- a/src/v2/layout/AppShell.tsx
+++ b/src/v2/layout/AppShell.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import { Avatar } from '../components/Avatar'
+import { useTheme } from '../hooks/useTheme'
+
+const NAV_ITEMS = [
+  { key: 'home', label: 'Home', path: '/v2/home' },
+  { key: 'teachers', label: 'Teachers', path: '/v2/teachers' },
+  { key: 'observation', label: 'Observation', path: '/v2/observation' },
+  { key: 'plans', label: 'Plans', path: '/v2/plans' },
+  { key: 'training', label: 'Training', path: '/v2/training' }
+]
+
+export function AppShell(props: {
+  activeKey: string
+  user?: { name: string; role?: string }
+  children: React.ReactNode
+  onNavigate?: (path: string) => void
+}) {
+  const { theme, toggle } = useTheme()
+  const userName = props.user?.name ?? 'Guest'
+
+  return (
+    <>
+      <nav style={{
+        background: 'var(--v2-white)',
+        borderBottom: '1px solid var(--v2-line)',
+        padding: '0.85rem 1.75rem',
+        position: 'sticky',
+        top: 0,
+        zIndex: 100,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem', fontWeight: 700, fontSize: '1.1rem', letterSpacing: '-0.01em' }}>
+          <div style={{
+            width: 32, height: 32,
+            background: 'var(--v2-ink)',
+            color: 'var(--v2-white)',
+            borderRadius: 7,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, fontSize: '0.9rem'
+          }}>C</div>
+          <span>CHALK</span>
+          <span style={{
+            fontSize: '0.6rem',
+            letterSpacing: '0.18em',
+            background: 'var(--v2-warm)',
+            color: '#fff',
+            padding: '0.12rem 0.5rem',
+            borderRadius: 4,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            marginLeft: '0.45rem'
+          }}>2.0</span>
+        </div>
+
+        <div style={{
+          display: 'flex',
+          gap: '0.25rem',
+          position: 'absolute',
+          left: '50%',
+          transform: 'translateX(-50%)'
+        }}>
+          {NAV_ITEMS.map(item => {
+            const active = item.key === props.activeKey
+            return (
+              <a
+                key={item.key}
+                onClick={(e) => { e.preventDefault(); props.onNavigate?.(item.path) }}
+                href={item.path}
+                style={{
+                  fontSize: '0.88rem',
+                  fontWeight: active ? 600 : 500,
+                  color: active ? 'var(--v2-brand-darker)' : 'var(--v2-muted)',
+                  padding: '0.55rem 1rem',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  position: 'relative',
+                  transition: 'color 0.15s',
+                  textDecoration: 'none'
+                }}
+              >
+                {item.label}
+                {active && (
+                  <span style={{
+                    position: 'absolute',
+                    bottom: '-0.95rem',
+                    left: '1rem', right: '1rem',
+                    height: 2,
+                    background: 'var(--v2-brand)',
+                    borderRadius: 2
+                  }} />
+                )}
+              </a>
+            )
+          })}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.85rem' }}>
+          <button
+            onClick={toggle}
+            title="Toggle theme"
+            style={{
+              width: 36, height: 36,
+              borderRadius: '50%',
+              background: 'var(--v2-bg-soft)',
+              border: '1px solid transparent',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: '1rem', cursor: 'pointer'
+            }}
+          >
+            {theme === 'light' ? '🌙' : '☀️'}
+          </button>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '0.55rem',
+            padding: '0.3rem 0.85rem 0.3rem 0.3rem',
+            background: 'var(--v2-bg-soft)',
+            borderRadius: 'var(--v2-radius-pill)',
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            color: 'var(--v2-ink-soft)',
+            cursor: 'pointer'
+          }}>
+            <Avatar name={userName} size={28} />
+            <span>{userName.split(' ')[0]}</span>
+          </div>
+        </div>
+      </nav>
+      <main>{props.children}</main>
+    </>
+  )
+}

--- a/src/v2/lib/api.ts
+++ b/src/v2/lib/api.ts
@@ -13,6 +13,25 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
+type ObservationDraftPayload = {
+  teacherUid: string
+  teacherName?: string
+  classroomName?: string
+  sessionName?: string
+  typeCode: string
+  storedType: string
+  notes: string
+  elapsedSeconds: number
+  updatedAt: Date
+}
+
+type ObservationCompletePayload = ObservationDraftPayload & {
+  alignedTags: string[]
+  strength: string
+  opportunity: string
+  nextStep: string
+}
+
 export function lastNDays(days: number): DateRange {
   const endDate = new Date()
   const startDate = new Date(endDate.getTime() - days * DAY_MS)
@@ -202,7 +221,7 @@ export async function saveActionPlanField(firebase: any, planId: string, patch: 
   return getActionPlanFull(firebase, planId)
 }
 
-export async function saveActionPlanDraft(firebase: any, planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null }): Promise<PlanDetail | null> {
+export async function saveActionPlanDraft(firebase: any, planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null; steps?: PlanDetail['steps'] }): Promise<PlanDetail | null> {
   const update: any = {
     dateModified: new Date()
   }
@@ -213,6 +232,21 @@ export async function saveActionPlanDraft(firebase: any, planId: string, patch: 
   if (patch.dueDate !== undefined) update.goalTimeline = patch.dueDate
 
   await firebase.db.collection('actionPlans').doc(planId).update(update)
+
+  if (patch.steps) {
+    await Promise.all(patch.steps.map((step, index) => {
+      if (firebase.saveActionStep) {
+        return firebase.saveActionStep(planId, String(index), step.step || '', step.person || '', step.timeline || null)
+      }
+
+      return firebase.db.collection('actionPlans').doc(planId).collection('actionSteps').doc(String(index)).set({
+        step: step.step || '',
+        person: step.person || '',
+        timeline: step.timeline || null
+      }, { merge: true })
+    }))
+  }
+
   return getActionPlanFull(firebase, planId)
 }
 
@@ -255,17 +289,64 @@ export async function startObservation(firebase: any, coachUid: string, teacherU
   return { coachUid, teacherUid, type: storedType, startedAt: new Date() }
 }
 
-export async function endObservation(firebase: any): Promise<{ completed: boolean }> {
+export async function saveObservationDraft(firebase: any, coachUid: string, draft: ObservationDraftPayload): Promise<{ saved: boolean }> {
+  await firebase.db.collection('users').doc(coachUid).set({ observationDraft: draft }, { merge: true })
+  return { saved: true }
+}
+
+export async function completeObservation(firebase: any, coachUid: string, payload: ObservationCompletePayload): Promise<{ completed: boolean; observationId?: string | null }> {
+  const notes = payload.notes.trim()
+  if (notes && firebase.handlePushNotes) {
+    firebase.handlePushNotes(notes)
+  }
+
+  if (firebase.handlePushNotes) {
+    firebase.handlePushNotes([
+      `Framework alignment: ${payload.alignedTags.join(', ') || 'Not recorded'}`,
+      `Strength: ${payload.strength || 'Not recorded'}`,
+      `Opportunity: ${payload.opportunity || 'Not recorded'}`,
+      `Next step: ${payload.nextStep || 'Not recorded'}`
+    ].join('\n'))
+  }
+
   firebase.endSession(new Date())
-  return { completed: true }
+  await firebase.db.collection('users').doc(coachUid).set({ observationDraft: null }, { merge: true })
+  return { completed: true, observationId: firebase.sessionRef?.id || null }
 }
 
 export async function getTrainingRecommendations(firebase: any, uid: string): Promise<TrainingCard[]> {
   return [
-    { id: 'transitions', title: 'Smooth Transitions', icon: 'Timer', tone: 'warm', reason: 'alert', reasonText: 'Recommended from recent observations', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
-    { id: 'questions', title: 'Open-Ended Questions', icon: 'Message', tone: 'brand', reason: 'alert', reasonText: 'Recurring coaching theme', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
-    { id: 'climate', title: 'Classroom Climate', icon: 'Heart', tone: 'success', reason: 'win', reasonText: 'Refresh available', ctaText: 'Refresh (8 min)' }
+    { id: 'transitions', title: 'Smooth Transitions', icon: '⏱', tone: 'warm', reason: 'alert', reasonText: 'Recommended from recent observations', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
+    { id: 'questions', title: 'Open-Ended Questions', icon: '🗣', tone: 'brand', reason: 'alert', reasonText: 'Recurring coaching theme', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
+    { id: 'climate', title: 'Classroom Climate', icon: '💚', tone: 'success', reason: 'win', reasonText: 'Refresh available', ctaText: 'Refresh (8 min)' },
+    { id: 'discipline', title: 'Conscious Discipline Foundations', icon: '📚', tone: 'purple', reason: 'skip', reasonText: 'Completed previously — skip unless needed', ctaText: 'Review notes' },
+    { id: 'magic9', title: 'Using Magic 9 effectively', icon: '📊', tone: 'gold', reason: 'skip', reasonText: 'Optional for experienced coaches', ctaText: 'Not now' },
+    { id: 'plans', title: 'Writing better action plans', icon: '🎯', tone: 'warm', reason: 'alert', reasonText: 'Recommended when goals are not measurable', ctaText: 'Start (12 min)', ctaVariant: 'primary' }
   ]
+}
+
+export async function getTrainingStatus(firebase: any, uid: string): Promise<Record<string, { completedAt?: any; dismissedAt?: any }>> {
+  const doc = await firebase.db.collection('users').doc(uid).get()
+  const data = doc.exists ? doc.data() || {} : {}
+  return data.v2TrainingStatus || {}
+}
+
+export async function markTrainingCompleted(firebase: any, uid: string, trainingId: string): Promise<{ completed: boolean }> {
+  await firebase.db.collection('users').doc(uid).set({
+    v2TrainingStatus: {
+      [trainingId]: { completedAt: new Date() }
+    }
+  }, { merge: true })
+  return { completed: true }
+}
+
+export async function dismissTrainingRecommendation(firebase: any, uid: string, trainingId: string): Promise<{ dismissed: boolean }> {
+  await firebase.db.collection('users').doc(uid).set({
+    v2TrainingStatus: {
+      [trainingId]: { dismissedAt: new Date() }
+    }
+  }, { merge: true })
+  return { dismissed: true }
 }
 
 export function createV2Api(firebase: any) {
@@ -277,11 +358,15 @@ export function createV2Api(firebase: any) {
     getTeachersForCoach: (uid: string, range?: DateRange) => getTeachersForCoach(firebase, uid, range),
     getActionPlanFull: (planId: string) => getActionPlanFull(firebase, planId),
     saveActionPlanField: (planId: string, patch: Partial<PlanDetail>) => saveActionPlanField(firebase, planId, patch),
-    saveActionPlanDraft: (planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null }) => saveActionPlanDraft(firebase, planId, patch),
+    saveActionPlanDraft: (planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null; steps?: PlanDetail['steps'] }) => saveActionPlanDraft(firebase, planId, patch),
     addActionPlanComment: (planId: string, comment: { authorName: string; authorId?: string; text: string }) => addActionPlanComment(firebase, planId, comment),
     markActionPlanSentToTeacher: (planId: string, sentBy: string) => markActionPlanSentToTeacher(firebase, planId, sentBy),
     startObservation: (coachUid: string, teacherUid: string, typeCode: string) => startObservation(firebase, coachUid, teacherUid, typeCode),
-    endObservation: () => endObservation(firebase),
-    getTrainingRecommendations: (uid: string) => getTrainingRecommendations(firebase, uid)
+    saveObservationDraft: (coachUid: string, draft: ObservationDraftPayload) => saveObservationDraft(firebase, coachUid, draft),
+    completeObservation: (coachUid: string, payload: ObservationCompletePayload) => completeObservation(firebase, coachUid, payload),
+    getTrainingRecommendations: (uid: string) => getTrainingRecommendations(firebase, uid),
+    getTrainingStatus: (uid: string) => getTrainingStatus(firebase, uid),
+    markTrainingCompleted: (uid: string, trainingId: string) => markTrainingCompleted(firebase, uid, trainingId),
+    dismissTrainingRecommendation: (uid: string, trainingId: string) => dismissTrainingRecommendation(firebase, uid, trainingId)
   }
 }

--- a/src/v2/lib/api.ts
+++ b/src/v2/lib/api.ts
@@ -1,0 +1,287 @@
+import { getStoredObservationType } from './observationTypes'
+import {
+  ActivityItem,
+  AttentionItem,
+  DashboardStats,
+  DateRange,
+  ObservationSession,
+  PlanDetail,
+  PlanItem,
+  TeacherRow,
+  TrainingCard
+} from './types'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function lastNDays(days: number): DateRange {
+  const endDate = new Date()
+  const startDate = new Date(endDate.getTime() - days * DAY_MS)
+  return { startDate, endDate }
+}
+
+function toDate(value: any): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return value
+  if (value.toDate) return value.toDate()
+  if (value.seconds) return new Date(value.seconds * 1000)
+  return null
+}
+
+function formatDate(value: any): string {
+  const date = toDate(value)
+  return date ? date.toLocaleString() : 'Never'
+}
+
+function fullName(data: any): string {
+  return `${data?.firstName || ''} ${data?.lastName || ''}`.trim() || 'Unknown teacher'
+}
+
+function roleOf(value: string): TeacherRow['role'] {
+  if (value === 'coach' || value === 'admin' || value === 'siteLeader' || value === 'programLeader') {
+    return value
+  }
+  return 'teacher'
+}
+
+async function resolveTeacherDocs(firebase: any): Promise<any[]> {
+  const raw = await firebase.getTeacherList()
+  const list = Array.isArray(raw) ? raw : []
+  return Promise.all(list.map(item => Promise.resolve(item)))
+}
+
+export async function getTeachersForCoach(firebase: any, uid: string, range: DateRange = lastNDays(30)): Promise<TeacherRow[]> {
+  const [teachers, loginCounts, actionCounts] = await Promise.all([
+    resolveTeacherDocs(firebase),
+    firebase.getUsersLoginCounts(range.startDate, range.endDate),
+    firebase.getUsersActionCounts(range.startDate, range.endDate)
+  ])
+
+  return teachers.map((teacher: any) => {
+    const id = teacher.id || teacher.uid || teacher.email || ''
+    const action = actionCounts.get(id)
+    return {
+      id,
+      firstName: teacher.firstName || '',
+      lastName: teacher.lastName || '',
+      role: roleOf(teacher.role),
+      program: teacher.program || teacher.school || 'Unassigned',
+      status: teacher.archived ? 'archived' : 'active',
+      lastLogin: formatDate(teacher.lastLogin),
+      loginCount: loginCounts.get(id) || 0,
+      actionCount: action ? action.total : 0,
+      lastAction: {
+        type: teacher.lastActionType || 'None',
+        date: formatDate(teacher.lastAction)
+      }
+    }
+  })
+}
+
+export async function getActivePlans(firebase: any, uid: string): Promise<PlanItem[]> {
+  const plans = await firebase.getCoachActionPlans()
+  const list = Array.isArray(plans) ? plans : []
+  return list
+    .filter((plan: any) => plan.status !== 'complete' && plan.status !== 'archived')
+    .sort((a: any, b: any) => (b.modified || 0) - (a.modified || 0))
+    .slice(0, 2)
+    .map((plan: any) => ({
+      id: plan.id,
+      title: plan.practice || 'Action plan',
+      forName: `${plan.teacherFirstName || ''} ${plan.teacherLastName || ''}`.trim() || plan.teacherId || 'Teacher',
+      progress: plan.status === 'inProgress' ? 65 : 30,
+      due: toDate(plan.achieveBy) ? `Due ${toDate(plan.achieveBy)?.toLocaleDateString()}` : 'No due date'
+    }))
+}
+
+export async function getDashboardStats(firebase: any, uid: string, range: DateRange = lastNDays(7)): Promise<DashboardStats> {
+  const [teachers, activePlans] = await Promise.all([
+    getTeachersForCoach(firebase, uid, lastNDays(30)),
+    getActivePlans(firebase, uid)
+  ])
+
+  let observationsThisWeek = 0
+  try {
+    const snapshot = await firebase.db.collection('observations')
+      .where('observedBy', '==', `/user/${uid}`)
+      .where('end', '>=', range.startDate)
+      .where('end', '<=', range.endDate)
+      .get()
+    observationsThisWeek = snapshot.size
+  } catch (error) {
+    console.error('Unable to load v2 dashboard observation count', error)
+  }
+
+  const needAttention = teachers.filter(teacher => teacher.actionCount === 0 || teacher.lastLogin === 'Never').length
+  return {
+    underCoaching: teachers.filter(teacher => teacher.role === 'teacher' && teacher.status === 'active').length,
+    needAttention,
+    observationsThisWeek,
+    activePlans: activePlans.length
+  }
+}
+
+export async function getCoachAttention(firebase: any, uid: string, opts: { limit?: number } = {}): Promise<AttentionItem[]> {
+  const teachers = await getTeachersForCoach(firebase, uid, lastNDays(45))
+  return teachers
+    .filter(teacher => teacher.status === 'active')
+    .map(teacher => {
+      const inactive = teacher.lastLogin === 'Never' || teacher.loginCount === 0
+      const noActions = teacher.actionCount === 0
+      return {
+        id: teacher.id,
+        name: `${teacher.firstName} ${teacher.lastName}`.trim(),
+        reason: inactive
+          ? { text: 'No recent login', variant: 'warn' as const }
+          : noActions
+            ? { text: 'No recent activity', variant: 'neutral' as const }
+            : { text: 'Follow-up due', variant: 'warn' as const },
+        context: `${teacher.role} · ${teacher.program}`,
+        cta: noActions ? 'Start obs' : 'Open profile'
+      }
+    })
+    .slice(0, opts.limit || 4)
+}
+
+export async function getRecentActivity(firebase: any, uid: string, limit: number = 4): Promise<ActivityItem[]> {
+  const range = lastNDays(30)
+  const teachers = await getTeachersForCoach(firebase, uid, range)
+  return teachers
+    .filter(teacher => teacher.lastAction.type !== 'None')
+    .slice(0, limit)
+    .map(teacher => ({
+      id: `${teacher.id}-${teacher.lastAction.type}`,
+      title: teacher.lastAction.type,
+      meta: `${teacher.firstName} ${teacher.lastName} · ${teacher.lastAction.date}`,
+      tone: teacher.actionCount > 0 ? 'success' : 'brand'
+    }))
+}
+
+export async function getActionPlanFull(firebase: any, planId: string): Promise<PlanDetail | null> {
+  const doc = await firebase.db.collection('actionPlans').doc(planId).get()
+  if (!doc.exists) {
+    return null
+  }
+
+  const data = doc.data() || {}
+  const [steps, commentsSnapshot] = await Promise.all([
+    firebase.getActionStepsForExport(planId),
+    firebase.db.collection('actionPlans').doc(planId).collection('comments').orderBy('createdAt', 'asc').get().catch(() => null)
+  ])
+
+  const comments = commentsSnapshot
+    ? commentsSnapshot.docs.map(commentDoc => {
+      const comment = commentDoc.data()
+      return {
+        id: commentDoc.id,
+        name: comment.authorName || 'CHALK user',
+        time: formatDate(comment.createdAt),
+        text: comment.text || ''
+      }
+    })
+    : []
+
+  return {
+    id: doc.id,
+    title: data.tool || data.practice || 'Action plan',
+    teacherId: data.teacher || '',
+    teacherName: data.teacherName || fullName({ firstName: data.teacherFirstName, lastName: data.teacherLastName }),
+    goal: data.goal || '',
+    benefit: data.benefit || '',
+    dueDate: toDate(data.goalTimeline || data.achieveBy),
+    progress: data.status === 'complete' ? 100 : 65,
+    steps: Array.isArray(steps) ? steps : [],
+    comments
+  }
+}
+
+export async function saveActionPlanField(firebase: any, planId: string, patch: Partial<PlanDetail>): Promise<PlanDetail | null> {
+  await firebase.db.collection('actionPlans').doc(planId).update({
+    ...patch,
+    dateModified: new Date()
+  })
+  return getActionPlanFull(firebase, planId)
+}
+
+export async function saveActionPlanDraft(firebase: any, planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null }): Promise<PlanDetail | null> {
+  const update: any = {
+    dateModified: new Date()
+  }
+
+  if (patch.title !== undefined) update.tool = patch.title
+  if (patch.goal !== undefined) update.goal = patch.goal
+  if (patch.benefit !== undefined) update.benefit = patch.benefit
+  if (patch.dueDate !== undefined) update.goalTimeline = patch.dueDate
+
+  await firebase.db.collection('actionPlans').doc(planId).update(update)
+  return getActionPlanFull(firebase, planId)
+}
+
+export async function addActionPlanComment(firebase: any, planId: string, comment: { authorName: string; authorId?: string; text: string }): Promise<{ id: string; name: string; time: string; text: string }> {
+  const createdAt = new Date()
+  const ref = await firebase.db.collection('actionPlans').doc(planId).collection('comments').add({
+    authorName: comment.authorName,
+    authorId: comment.authorId || null,
+    text: comment.text,
+    createdAt
+  })
+
+  return {
+    id: ref.id,
+    name: comment.authorName,
+    time: formatDate(createdAt),
+    text: comment.text
+  }
+}
+
+export async function markActionPlanSentToTeacher(firebase: any, planId: string, sentBy: string): Promise<{ sent: boolean }> {
+  await firebase.db.collection('actionPlans').doc(planId).update({
+    sentToTeacher: true,
+    sentToTeacherAt: new Date(),
+    sentToTeacherBy: sentBy,
+    dateModified: new Date()
+  })
+
+  return { sent: true }
+}
+
+export async function startObservation(firebase: any, coachUid: string, teacherUid: string, typeCode: string): Promise<ObservationSession> {
+  const storedType = getStoredObservationType(typeCode) || typeCode
+  await firebase.handleSession({
+    observedBy: coachUid,
+    teacher: teacherUid,
+    type: storedType,
+    checklist: typeCode === 'LI' ? 'LI' : undefined
+  })
+  return { coachUid, teacherUid, type: storedType, startedAt: new Date() }
+}
+
+export async function endObservation(firebase: any): Promise<{ completed: boolean }> {
+  firebase.endSession(new Date())
+  return { completed: true }
+}
+
+export async function getTrainingRecommendations(firebase: any, uid: string): Promise<TrainingCard[]> {
+  return [
+    { id: 'transitions', title: 'Smooth Transitions', icon: 'Timer', tone: 'warm', reason: 'alert', reasonText: 'Recommended from recent observations', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
+    { id: 'questions', title: 'Open-Ended Questions', icon: 'Message', tone: 'brand', reason: 'alert', reasonText: 'Recurring coaching theme', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
+    { id: 'climate', title: 'Classroom Climate', icon: 'Heart', tone: 'success', reason: 'win', reasonText: 'Refresh available', ctaText: 'Refresh (8 min)' }
+  ]
+}
+
+export function createV2Api(firebase: any) {
+  return {
+    getCoachAttention: (uid: string, opts?: { limit?: number }) => getCoachAttention(firebase, uid, opts),
+    getDashboardStats: (uid: string, range?: DateRange) => getDashboardStats(firebase, uid, range),
+    getRecentActivity: (uid: string, limit?: number) => getRecentActivity(firebase, uid, limit),
+    getActivePlans: (uid: string) => getActivePlans(firebase, uid),
+    getTeachersForCoach: (uid: string, range?: DateRange) => getTeachersForCoach(firebase, uid, range),
+    getActionPlanFull: (planId: string) => getActionPlanFull(firebase, planId),
+    saveActionPlanField: (planId: string, patch: Partial<PlanDetail>) => saveActionPlanField(firebase, planId, patch),
+    saveActionPlanDraft: (planId: string, patch: { title?: string; goal?: string; benefit?: string; dueDate?: Date | null }) => saveActionPlanDraft(firebase, planId, patch),
+    addActionPlanComment: (planId: string, comment: { authorName: string; authorId?: string; text: string }) => addActionPlanComment(firebase, planId, comment),
+    markActionPlanSentToTeacher: (planId: string, sentBy: string) => markActionPlanSentToTeacher(firebase, planId, sentBy),
+    startObservation: (coachUid: string, teacherUid: string, typeCode: string) => startObservation(firebase, coachUid, teacherUid, typeCode),
+    endObservation: () => endObservation(firebase),
+    getTrainingRecommendations: (uid: string) => getTrainingRecommendations(firebase, uid)
+  }
+}

--- a/src/v2/lib/firebase.ts
+++ b/src/v2/lib/firebase.ts
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import Firebase, { FirebaseContext } from '../../components/Firebase'
+
+const V2FirebaseContext = React.createContext<Firebase | null>(null)
+
+export function V2FirebaseProvider(props: { children: React.ReactNode }) {
+  const firebase = React.useContext(FirebaseContext)
+  return React.createElement(V2FirebaseContext.Provider, { value: firebase }, props.children)
+}
+
+export function useV2Firebase(): Firebase {
+  const firebase = React.useContext(V2FirebaseContext)
+  if (!firebase) {
+    throw new Error('useV2Firebase must be used inside V2FirebaseProvider')
+  }
+  return firebase
+}

--- a/src/v2/lib/observationTypes.ts
+++ b/src/v2/lib/observationTypes.ts
@@ -1,0 +1,41 @@
+export type ObservationUiCode = 'TT' | 'CC' | 'MI' | 'SE' | 'IN' | 'LC' | 'SA' | 'AC' | 'LI'
+
+export type StoredObservationType =
+  | 'transition'
+  | 'climate'
+  | 'math'
+  | 'engagement'
+  | 'level'
+  | 'listening'
+  | 'sequential'
+  | 'AC'
+  | 'LI'
+
+export type ObservationTypeOption = {
+  code: ObservationUiCode
+  label: string
+  storedType: StoredObservationType
+  description: string
+  requiresChecklist?: boolean
+}
+
+export const OBSERVATION_TYPE_OPTIONS: ObservationTypeOption[] = [
+  { code: 'TT', label: 'Transition Time', storedType: 'transition', description: 'Transitions between routines and activities.' },
+  { code: 'CC', label: 'Classroom Climate', storedType: 'climate', description: 'Warmth, responsiveness, and classroom tone.' },
+  { code: 'MI', label: 'Math Instruction', storedType: 'math', description: 'Mathematical talk, problem solving, and concepts.' },
+  { code: 'SE', label: 'Student Engagement', storedType: 'engagement', description: 'Active participation and sustained attention.' },
+  { code: 'IN', label: 'Level of Instruction', storedType: 'level', description: 'Instructional depth and scaffolding.' },
+  { code: 'LC', label: 'Listening to Children', storedType: 'listening', description: 'Teacher listening, uptake, and child voice.' },
+  { code: 'SA', label: 'Sequential Activities', storedType: 'sequential', description: 'Clear sequences and connected learning activities.' },
+  { code: 'AC', label: 'Associative and Cooperative', storedType: 'AC', description: 'Peer interaction and cooperative play.' },
+  { code: 'LI', label: 'Literacy Instruction', storedType: 'LI', description: 'Literacy instruction with the existing checklist path.', requiresChecklist: true }
+]
+
+export function getObservationTypeOption(code?: string | null): ObservationTypeOption | undefined {
+  return OBSERVATION_TYPE_OPTIONS.find(option => option.code === code)
+}
+
+export function getStoredObservationType(code?: string | null): StoredObservationType | undefined {
+  const option = getObservationTypeOption(code)
+  return option ? option.storedType : undefined
+}

--- a/src/v2/lib/types.ts
+++ b/src/v2/lib/types.ts
@@ -1,0 +1,105 @@
+export type AttentionVariant = 'warn' | 'danger' | 'neutral'
+
+export type V2User = {
+  uid: string
+  email: string
+  isAnonymous: boolean
+  firstName: string
+  lastName: string
+  role: string
+  programs?: string[]
+  sites?: string[]
+}
+
+export type DateRange = {
+  startDate: Date
+  endDate: Date
+}
+
+export type DashboardStats = {
+  underCoaching: number
+  needAttention: number
+  observationsThisWeek: number
+  activePlans: number
+}
+
+export type AttentionItem = {
+  id: string
+  name: string
+  reason: { text: string; variant: AttentionVariant }
+  context: string
+  cta: string
+}
+
+export type ActivityItem = {
+  id: string
+  title: string
+  meta: string
+  tone: 'success' | 'brand' | 'warn'
+  date?: Date | null
+}
+
+export type PlanItem = {
+  id: string
+  title: string
+  forName: string
+  progress: number
+  due: string
+}
+
+export type TeacherRow = {
+  id: string
+  firstName: string
+  lastName: string
+  role: 'teacher' | 'coach' | 'admin' | 'siteLeader' | 'programLeader'
+  program: string
+  status: 'active' | 'archived'
+  lastLogin: string
+  loginCount: number
+  actionCount: number
+  lastAction: { type: string; date: string }
+}
+
+export type PlanComment = {
+  id: string
+  name: string
+  time: string
+  text: string
+}
+
+export type PlanStep = {
+  step: string | null
+  person: string | null
+  timeline: Date | null
+}
+
+export type PlanDetail = {
+  id: string
+  title: string
+  teacherId: string
+  teacherName: string
+  goal: string
+  benefit: string
+  dueDate: Date | null
+  progress: number
+  steps: PlanStep[]
+  comments: PlanComment[]
+}
+
+export type ObservationSession = {
+  coachUid: string
+  teacherUid: string
+  type: string
+  startedAt: Date
+}
+
+export type TrainingCard = {
+  id: string
+  title: string
+  icon: string
+  tone: 'warm' | 'brand' | 'success' | 'gold' | 'purple'
+  reason: 'alert' | 'win' | 'skip'
+  reasonText: string
+  ctaText: string
+  ctaVariant?: 'default' | 'primary'
+}

--- a/src/v2/pages/AllTeachers.tsx
+++ b/src/v2/pages/AllTeachers.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react'
 import { Avatar } from '../components/Avatar'
 import { Button } from '../components/Button'
+import { EmptyState } from '../components/EmptyState'
 import { Pill } from '../components/Pill'
+import { TableSkeleton } from '../components/Skeleton'
+import { useToast } from '../hooks/useToast'
+import { useV2Auth } from '../hooks/useV2Auth'
+import { useV2Firebase } from '../lib/firebase'
+import { createV2Api } from '../lib/api'
 
 type TeacherRow = {
   id: string
@@ -17,24 +23,24 @@ type TeacherRow = {
 }
 
 const ROWS: TeacherRow[] = [
-  { id: '1', firstName: 'Dawn', lastName: 'Johnson', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/19/26, 8:32 AM', loginCount: 14, actionCount: 8, lastAction: { type: 'Observation', date: '5/18/26, 2:14 PM' } },
-  { id: '2', firstName: 'Chrystaline', lastName: 'Glenn', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/20/26, 9:15 AM', loginCount: 22, actionCount: 12, lastAction: { type: 'Action Plan', date: '5/19/26, 4:42 PM' } },
-  { id: '3', firstName: 'Kerry', lastName: 'Leedy', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/14/26, 9:05 PM', loginCount: 7, actionCount: 3, lastAction: { type: 'Observation', date: '5/14/26, 9:05 PM' } },
-  { id: '4', firstName: 'Shonnell', lastName: 'Wilkins', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/17/26, 7:18 AM', loginCount: 5, actionCount: 2, lastAction: { type: 'Observation', date: '5/15/26, 10:22 AM' } },
-  { id: '5', firstName: 'Cassie', lastName: 'Sexton', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/19/26, 2:48 PM', loginCount: 9, actionCount: 5, lastAction: { type: 'Training', date: '5/19/26, 3:00 PM' } },
-  { id: '6', firstName: 'Rene’e', lastName: 'Johnson', role: 'teacher', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/18/26, 11:02 AM', loginCount: 6, actionCount: 1, lastAction: { type: 'Observation', date: '5/12/26, 9:30 AM' } },
-  { id: '7', firstName: 'Nicole', lastName: 'Broomfield', role: 'teacher', program: 'Excel Prep Academy', status: 'active', lastLogin: '5/19/26, 4:14 PM', loginCount: 11, actionCount: 4, lastAction: { type: 'Conference Plan', date: '5/16/26, 1:48 PM' } },
-  { id: '8', firstName: 'Tyquaona', lastName: 'Montgomery', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/13/26, 8:01 AM', loginCount: 4, actionCount: 2, lastAction: { type: 'Email', date: '5/13/26, 10:11 AM' } },
-  { id: '9', firstName: 'Ann', lastName: 'James', role: 'teacher', program: 'Rex Childcare & Early Learning', status: 'active', lastLogin: 'Never', loginCount: 0, actionCount: 1, lastAction: { type: 'Observation', date: '5/11/26, 2:00 PM' } },
-  { id: '10', firstName: 'Michelle', lastName: 'Kreitzer', role: 'teacher', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/20/26, 7:42 AM', loginCount: 18, actionCount: 6, lastAction: { type: 'Conference Plan', date: '5/19/26, 11:30 AM' } },
-  { id: '11', firstName: 'Ciera', lastName: 'Davis', role: 'teacher', program: 'United Way', status: 'active', lastLogin: '5/16/26, 1:22 PM', loginCount: 3, actionCount: 1, lastAction: { type: 'Observation', date: '5/16/26, 2:45 PM' } },
-  { id: '12', firstName: 'Ja’Naye', lastName: 'Lattimore', role: 'teacher', program: 'United Way', status: 'active', lastLogin: '5/18/26, 9:55 AM', loginCount: 8, actionCount: 4, lastAction: { type: 'Training', date: '5/18/26, 10:30 AM' } },
-  { id: '13', firstName: 'Mitzi', lastName: 'Keesee', role: 'teacher', program: 'Excel Prep Academy', status: 'active', lastLogin: '5/15/26, 3:12 PM', loginCount: 6, actionCount: 2, lastAction: { type: 'Action Plan', date: '5/14/26, 4:22 PM' } },
-  { id: '14', firstName: 'Tina', lastName: 'Arnold', role: 'teacher', program: 'Preschool Promise', status: 'archived', lastLogin: '11/13/24, 1:20 PM', loginCount: 0, actionCount: 0, lastAction: { type: 'Email', date: '11/13/24, 1:20 PM' } },
-  { id: '15', firstName: 'Tisha', lastName: 'Owen', role: 'coach', program: 'Preschool Promise', status: 'active', lastLogin: '5/20/26, 7:01 AM', loginCount: 25, actionCount: 32, lastAction: { type: 'Observation', date: '5/20/26, 10:00 AM' } },
-  { id: '16', firstName: 'Dana', lastName: 'Al-Sarraj', role: 'coach', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/19/26, 4:30 PM', loginCount: 19, actionCount: 27, lastAction: { type: 'Conference Plan', date: '5/19/26, 5:00 PM' } },
-  { id: '17', firstName: 'Latara', lastName: 'Holt', role: 'coach', program: 'United Way', status: 'active', lastLogin: '5/20/26, 6:55 AM', loginCount: 21, actionCount: 24, lastAction: { type: 'Action Plan', date: '5/20/26, 9:14 AM' } },
-  { id: '18', firstName: 'Caroline', lastName: 'Christopher', role: 'admin', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/19/26, 11:10 AM', loginCount: 12, actionCount: 8, lastAction: { type: 'Email', date: '5/19/26, 11:20 AM' } },
+  { id: '1', firstName: 'Alex', lastName: 'Rivera', role: 'teacher', program: 'Demo Early Learning', status: 'active', lastLogin: '5/19/26, 8:32 AM', loginCount: 14, actionCount: 8, lastAction: { type: 'Observation', date: '5/18/26, 2:14 PM' } },
+  { id: '2', firstName: 'Morgan', lastName: 'Lee', role: 'teacher', program: 'River Center Demo', status: 'active', lastLogin: '5/20/26, 9:15 AM', loginCount: 22, actionCount: 12, lastAction: { type: 'Action Plan', date: '5/19/26, 4:42 PM' } },
+  { id: '3', firstName: 'Jamie', lastName: 'Chen', role: 'teacher', program: 'Demo Early Learning', status: 'active', lastLogin: '5/14/26, 9:05 PM', loginCount: 7, actionCount: 3, lastAction: { type: 'Observation', date: '5/14/26, 9:05 PM' } },
+  { id: '4', firstName: 'Sam', lastName: 'Taylor', role: 'teacher', program: 'River Center Demo', status: 'active', lastLogin: '5/17/26, 7:18 AM', loginCount: 5, actionCount: 2, lastAction: { type: 'Observation', date: '5/15/26, 10:22 AM' } },
+  { id: '5', firstName: 'Casey', lastName: 'Brooks', role: 'teacher', program: 'Demo Early Learning', status: 'active', lastLogin: '5/19/26, 2:48 PM', loginCount: 9, actionCount: 5, lastAction: { type: 'Training', date: '5/19/26, 3:00 PM' } },
+  { id: '6', firstName: 'Riley', lastName: 'Nguyen', role: 'teacher', program: 'Campus Demo Center', status: 'active', lastLogin: '5/18/26, 11:02 AM', loginCount: 6, actionCount: 1, lastAction: { type: 'Observation', date: '5/12/26, 9:30 AM' } },
+  { id: '7', firstName: 'Jordan', lastName: 'Patel', role: 'teacher', program: 'Northside Demo Academy', status: 'active', lastLogin: '5/19/26, 4:14 PM', loginCount: 11, actionCount: 4, lastAction: { type: 'Conference Plan', date: '5/16/26, 1:48 PM' } },
+  { id: '8', firstName: 'Taylor', lastName: 'Morgan', role: 'teacher', program: 'River Center Demo', status: 'active', lastLogin: '5/13/26, 8:01 AM', loginCount: 4, actionCount: 2, lastAction: { type: 'Email', date: '5/13/26, 10:11 AM' } },
+  { id: '9', firstName: 'Avery', lastName: 'Quinn', role: 'teacher', program: 'Westside Demo Learning', status: 'active', lastLogin: 'Never', loginCount: 0, actionCount: 1, lastAction: { type: 'Observation', date: '5/11/26, 2:00 PM' } },
+  { id: '10', firstName: 'Emery', lastName: 'Stone', role: 'teacher', program: 'Campus Demo Center', status: 'active', lastLogin: '5/20/26, 7:42 AM', loginCount: 18, actionCount: 6, lastAction: { type: 'Conference Plan', date: '5/19/26, 11:30 AM' } },
+  { id: '11', firstName: 'Parker', lastName: 'Davis', role: 'teacher', program: 'Community Demo Network', status: 'active', lastLogin: '5/16/26, 1:22 PM', loginCount: 3, actionCount: 1, lastAction: { type: 'Observation', date: '5/16/26, 2:45 PM' } },
+  { id: '12', firstName: 'Quinn', lastName: 'Larsen', role: 'teacher', program: 'Community Demo Network', status: 'active', lastLogin: '5/18/26, 9:55 AM', loginCount: 8, actionCount: 4, lastAction: { type: 'Training', date: '5/18/26, 10:30 AM' } },
+  { id: '13', firstName: 'Harper', lastName: 'Kim', role: 'teacher', program: 'Northside Demo Academy', status: 'active', lastLogin: '5/15/26, 3:12 PM', loginCount: 6, actionCount: 2, lastAction: { type: 'Action Plan', date: '5/14/26, 4:22 PM' } },
+  { id: '14', firstName: 'Reese', lastName: 'Allen', role: 'teacher', program: 'Demo Early Learning', status: 'archived', lastLogin: '11/13/24, 1:20 PM', loginCount: 0, actionCount: 0, lastAction: { type: 'Email', date: '11/13/24, 1:20 PM' } },
+  { id: '15', firstName: 'Devon', lastName: 'Owen', role: 'coach', program: 'Demo Early Learning', status: 'active', lastLogin: '5/20/26, 7:01 AM', loginCount: 25, actionCount: 32, lastAction: { type: 'Observation', date: '5/20/26, 10:00 AM' } },
+  { id: '16', firstName: 'Marlowe', lastName: 'Reed', role: 'coach', program: 'Campus Demo Center', status: 'active', lastLogin: '5/19/26, 4:30 PM', loginCount: 19, actionCount: 27, lastAction: { type: 'Conference Plan', date: '5/19/26, 5:00 PM' } },
+  { id: '17', firstName: 'Skyler', lastName: 'Holt', role: 'coach', program: 'Community Demo Network', status: 'active', lastLogin: '5/20/26, 6:55 AM', loginCount: 21, actionCount: 24, lastAction: { type: 'Action Plan', date: '5/20/26, 9:14 AM' } },
+  { id: '18', firstName: 'Blair', lastName: 'Carter', role: 'admin', program: 'Campus Demo Center', status: 'active', lastLogin: '5/19/26, 11:10 AM', loginCount: 12, actionCount: 8, lastAction: { type: 'Email', date: '5/19/26, 11:20 AM' } },
 ]
 
 const roleLabel: Record<TeacherRow['role'], string> = {
@@ -42,10 +48,11 @@ const roleLabel: Record<TeacherRow['role'], string> = {
   coach: 'Coach', teacher: 'Teacher'
 }
 
-const FilterInput = (p: { placeholder: string; value?: string; width?: number }) => (
+const FilterInput = (p: { placeholder: string; value: string; onChange(value: string): void; width?: number }) => (
   <input
     placeholder={p.placeholder}
-    defaultValue={p.value}
+    value={p.value}
+    onChange={(event) => p.onChange(event.currentTarget.value)}
     style={{
       width: p.width ?? 200,
       padding: '0.55rem 0.95rem',
@@ -58,8 +65,11 @@ const FilterInput = (p: { placeholder: string; value?: string; width?: number })
   />
 )
 
-const Select = (p: { children: React.ReactNode }) => (
-  <select style={{
+const Select = (p: { children: React.ReactNode; value: string; onChange(value: string): void }) => (
+  <select
+    value={p.value}
+    onChange={(event) => p.onChange(event.currentTarget.value)}
+    style={{
     padding: '0.55rem 0.95rem',
     border: '1px solid var(--v2-line)',
     borderRadius: 'var(--v2-radius-pill)',
@@ -67,7 +77,10 @@ const Select = (p: { children: React.ReactNode }) => (
     background: 'var(--v2-white)',
     color: 'var(--v2-ink-soft)',
     cursor: 'pointer'
-  }}>{p.children}</select>
+  }}
+  >
+    {p.children}
+  </select>
 )
 
 const DateInput = (p: { value: string }) => (
@@ -99,6 +112,110 @@ const Preset = (p: { active?: boolean; children: React.ReactNode }) => (
 )
 
 export function AllTeachers() {
+  const firebase = useV2Firebase()
+  const auth = useV2Auth()
+  const toast = useToast()
+  const csvInputRef = React.useRef<HTMLInputElement | null>(null)
+  const [rows, setRows] = React.useState<TeacherRow[]>(ROWS)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+  const [search, setSearch] = React.useState('')
+  const [roleFilter, setRoleFilter] = React.useState('all')
+  const [statusFilter, setStatusFilter] = React.useState('active')
+  const [showAddModal, setShowAddModal] = React.useState(false)
+  const [draft, setDraft] = React.useState({ firstName: '', lastName: '', role: 'teacher', program: '' })
+
+  React.useEffect(() => {
+    if (!auth.user) {
+      return
+    }
+
+    let active = true
+    setLoading(true)
+    setError(null)
+    createV2Api(firebase).getTeachersForCoach(auth.user.uid).then(nextRows => {
+      if (!active) return
+      setRows(nextRows.length > 0 ? nextRows as TeacherRow[] : [])
+      setLoading(false)
+    }).catch(fetchError => {
+      if (!active) return
+      setError(fetchError as Error)
+      setLoading(false)
+    })
+
+    return () => { active = false }
+  }, [auth.user, firebase])
+
+  const normalizedSearch = search.trim().toLowerCase()
+  const filteredRows = rows.filter(row => {
+    const text = `${row.firstName} ${row.lastName} ${row.program} ${roleLabel[row.role]}`.toLowerCase()
+    const matchesSearch = normalizedSearch === '' || text.includes(normalizedSearch)
+    const matchesRole = roleFilter === 'all' || row.role === roleFilter
+    const matchesStatus = statusFilter === 'all' || row.status === statusFilter
+    return matchesSearch && matchesRole && matchesStatus
+  })
+
+  const addLocalTeammate = () => {
+    if (!draft.firstName.trim() || !draft.lastName.trim()) {
+      toast.error('First and last name are required.')
+      return
+    }
+
+    setRows(current => [{
+      id: `local-${Date.now()}`,
+      firstName: draft.firstName.trim(),
+      lastName: draft.lastName.trim(),
+      role: draft.role as TeacherRow['role'],
+      program: draft.program.trim() || 'Unassigned',
+      status: 'active',
+      lastLogin: 'Never',
+      loginCount: 0,
+      actionCount: 0,
+      lastAction: { type: 'None', date: 'Never' }
+    }, ...current])
+    setDraft({ firstName: '', lastName: '', role: 'teacher', program: '' })
+    setShowAddModal(false)
+    toast.success('Teammate added to this preview list.')
+  }
+
+  const importCsv = (file: File | null) => {
+    if (!file) {
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const content = String(reader.result || '')
+      const lines = content.split(/\r?\n/).filter(Boolean)
+      if (lines.length < 2) {
+        toast.error('CSV needs a header row and at least one teammate row.')
+        return
+      }
+
+      const headers = lines[0].split(',').map(header => header.trim().toLowerCase())
+      const imported = lines.slice(1).map((line, index) => {
+        const cols = line.split(',').map(col => col.trim())
+        const value = (name: string) => cols[headers.indexOf(name)] || ''
+        return {
+          id: `csv-${Date.now()}-${index}`,
+          firstName: value('firstname') || value('first_name') || value('first') || 'Imported',
+          lastName: value('lastname') || value('last_name') || value('last') || `Teacher ${index + 1}`,
+          role: (value('role') as TeacherRow['role']) || 'teacher',
+          program: value('program') || value('school') || 'Imported CSV',
+          status: 'active' as const,
+          lastLogin: 'Never',
+          loginCount: 0,
+          actionCount: 0,
+          lastAction: { type: 'None', date: 'Never' }
+        }
+      })
+
+      setRows(current => [...imported, ...current])
+      toast.success(`${imported.length} CSV rows added to this preview list.`)
+    }
+    reader.readAsText(file)
+  }
+
   return (
     <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       {/* Header */}
@@ -109,12 +226,19 @@ export function AllTeachers() {
         <div>
           <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>All Teachers</h1>
           <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
-            {ROWS.length} teammates · login activity and recent action data
+            {filteredRows.length} of {rows.length} teammates · login activity and recent action data
           </div>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <Button>📥 Import CSV</Button>
-          <Button variant="primary">+ Add teammate</Button>
+          <input
+            ref={csvInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            style={{ display: 'none' }}
+            onChange={(event) => importCsv(event.currentTarget.files ? event.currentTarget.files[0] : null)}
+          />
+          <Button onClick={() => csvInputRef.current?.click()}>📥 Import CSV</Button>
+          <Button variant="primary" onClick={() => setShowAddModal(true)}>+ Add teammate</Button>
         </div>
       </div>
 
@@ -127,14 +251,14 @@ export function AllTeachers() {
         boxShadow: 'var(--v2-shadow-sm)',
         marginBottom: '1rem',
         display: 'grid',
-        gridTemplateColumns: '1fr 1fr',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
         gap: '1rem',
         alignItems: 'center'
       }}>
         <div style={{ display: 'flex', gap: '0.65rem', flexWrap: 'wrap', alignItems: 'center' }}>
-          <FilterInput placeholder="🔍 Search teachers, programs, sites…" />
-          <Select><option>All roles</option><option>Teacher</option><option>Coach</option></Select>
-          <Select><option>Active</option><option>Archived</option></Select>
+          <FilterInput placeholder="🔍 Search teachers, programs, sites…" value={search} onChange={setSearch} />
+          <Select value={roleFilter} onChange={setRoleFilter}><option value="all">All roles</option><option value="teacher">Teacher</option><option value="coach">Coach</option><option value="admin">Admin</option><option value="siteLeader">Site Leader</option><option value="programLeader">Program Leader</option></Select>
+          <Select value={statusFilter} onChange={setStatusFilter}><option value="all">All statuses</option><option value="active">Active</option><option value="archived">Archived</option></Select>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'flex-end' }}>
           <span style={{ fontSize: '0.82rem', color: 'var(--v2-muted)', fontWeight: 500 }}>Date range:</span>
@@ -155,67 +279,114 @@ export function AllTeachers() {
         boxShadow: 'var(--v2-shadow-sm)',
         overflow: 'auto'
       }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', borderSpacing: 0, minWidth: 1100 }}>
-          <thead>
-            <tr style={{ background: 'var(--v2-bg-soft)' }}>
-              {['Name', 'Role · Program', 'Status', 'Last Login', 'Login Count', 'Action Count', 'Last Action'].map((h, i) => (
-                <th key={i} style={{
-                  textAlign: 'left',
-                  padding: '0.85rem 1rem',
-                  fontSize: '0.7rem',
-                  fontWeight: 700,
-                  letterSpacing: '0.06em',
-                  textTransform: 'uppercase',
-                  color: 'var(--v2-muted)',
-                  borderBottom: '1px solid var(--v2-line)'
-                }}>
-                  {h}
-                  {(h === 'Login Count' || h === 'Action Count') && (
-                    <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>Apr 20 – May 20</div>
-                  )}
-                  {h === 'Last Action' && (
-                    <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>all time</div>
-                  )}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {ROWS.map(r => (
-              <tr key={r.id} style={{ borderBottom: '1px solid var(--v2-line-soft)' }}>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem' }}>
-                    <Avatar name={`${r.firstName} ${r.lastName}`} size={30} />
-                    <strong>{r.firstName} {r.lastName}</strong>
-                  </div>
-                </td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
-                  {roleLabel[r.role]} · {r.program}
-                </td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
-                  <Pill variant={r.status === 'active' ? 'success' : 'neutral'}>
-                    {r.status === 'active' ? 'Active' : 'Archived'}
-                  </Pill>
-                </td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>{r.lastLogin}</td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>{r.loginCount}</td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>
-                  <span style={{ borderBottom: r.actionCount > 0 ? '1px dotted var(--v2-muted-soft)' : 'none', cursor: 'help' }}>
-                    {r.actionCount}
-                  </span>
-                </td>
-                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
-                  {r.lastAction.type} — {r.lastAction.date}
-                </td>
+        {loading ? (
+          <div style={{ padding: '1rem' }}>
+            <TableSkeleton rows={8} cols={7} />
+          </div>
+        ) : filteredRows.length === 0 ? (
+          <EmptyState title="No teammates match these filters" description="Adjust the search, role, status, or date range and try again." />
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', borderSpacing: 0, minWidth: 1100 }}>
+            <thead>
+              <tr style={{ background: 'var(--v2-bg-soft)' }}>
+                {['Name', 'Role · Program', 'Status', 'Last Login', 'Login Count', 'Action Count', 'Last Action'].map((h, i) => (
+                  <th key={i} style={{
+                    textAlign: 'left',
+                    padding: '0.85rem 1rem',
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    color: 'var(--v2-muted)',
+                    borderBottom: '1px solid var(--v2-line)'
+                  }}>
+                    {h}
+                    {(h === 'Login Count' || h === 'Action Count') && (
+                      <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>Last 30 days</div>
+                    )}
+                    {h === 'Last Action' && (
+                      <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>all time</div>
+                    )}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filteredRows.map(r => (
+                <tr key={r.id} style={{ borderBottom: '1px solid var(--v2-line-soft)' }}>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem' }}>
+                      <Avatar name={`${r.firstName} ${r.lastName}`} size={30} />
+                      <strong>{r.firstName} {r.lastName}</strong>
+                    </div>
+                  </td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
+                    {roleLabel[r.role]} · {r.program}
+                  </td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
+                    <Pill variant={r.status === 'active' ? 'success' : 'neutral'}>
+                      {r.status === 'active' ? 'Active' : 'Archived'}
+                    </Pill>
+                  </td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>{r.lastLogin}</td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>{r.loginCount}</td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>
+                    <span style={{ borderBottom: r.actionCount > 0 ? '1px dotted var(--v2-muted-soft)' : 'none', cursor: 'help' }}>
+                      {r.actionCount}
+                    </span>
+                  </td>
+                  <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
+                    {r.lastAction.type} — {r.lastAction.date}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
 
       <div style={{ marginTop: '1rem', fontSize: '0.82rem', color: 'var(--v2-muted)', textAlign: 'center' }}>
-        Showing 1-{ROWS.length} of {ROWS.length} records
+        {error ? 'Live data unavailable; showing current local rows' : `Showing ${filteredRows.length} of ${rows.length} records`}
       </div>
+
+      {showAddModal && (
+        <div style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(18, 24, 31, 0.28)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 900
+        }}>
+          <div style={{
+            width: 'min(420px, calc(100vw - 2rem))',
+            background: 'var(--v2-white)',
+            borderRadius: 10,
+            boxShadow: 'var(--v2-shadow-lg)',
+            padding: '1.25rem',
+            border: '1px solid var(--v2-line-soft)'
+          }}>
+            <h3 style={{ fontSize: '1rem', marginBottom: '0.9rem' }}>Add teammate</h3>
+            <div style={{ display: 'grid', gap: '0.7rem' }}>
+              <input placeholder="First name" value={draft.firstName} onChange={(event) => setDraft(current => ({ ...current, firstName: event.currentTarget.value }))} style={{ border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.7rem' }} />
+              <input placeholder="Last name" value={draft.lastName} onChange={(event) => setDraft(current => ({ ...current, lastName: event.currentTarget.value }))} style={{ border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.7rem' }} />
+              <select value={draft.role} onChange={(event) => setDraft(current => ({ ...current, role: event.currentTarget.value }))} style={{ border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.7rem', background: 'var(--v2-white)' }}>
+                <option value="teacher">Teacher</option>
+                <option value="coach">Coach</option>
+                <option value="siteLeader">Site Leader</option>
+                <option value="programLeader">Program Leader</option>
+                <option value="admin">Admin</option>
+              </select>
+              <input placeholder="Program or site" value={draft.program} onChange={(event) => setDraft(current => ({ ...current, program: event.currentTarget.value }))} style={{ border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.7rem' }} />
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem' }}>
+              <Button onClick={() => setShowAddModal(false)}>Cancel</Button>
+              <Button variant="primary" onClick={addLocalTeammate}>Add</Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/v2/pages/AllTeachers.tsx
+++ b/src/v2/pages/AllTeachers.tsx
@@ -1,0 +1,221 @@
+import * as React from 'react'
+import { Avatar } from '../components/Avatar'
+import { Button } from '../components/Button'
+import { Pill } from '../components/Pill'
+
+type TeacherRow = {
+  id: string
+  firstName: string
+  lastName: string
+  role: 'teacher' | 'coach' | 'admin' | 'siteLeader' | 'programLeader'
+  program: string
+  status: 'active' | 'archived'
+  lastLogin: string
+  loginCount: number
+  actionCount: number
+  lastAction: { type: string; date: string }
+}
+
+const ROWS: TeacherRow[] = [
+  { id: '1', firstName: 'Dawn', lastName: 'Johnson', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/19/26, 8:32 AM', loginCount: 14, actionCount: 8, lastAction: { type: 'Observation', date: '5/18/26, 2:14 PM' } },
+  { id: '2', firstName: 'Chrystaline', lastName: 'Glenn', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/20/26, 9:15 AM', loginCount: 22, actionCount: 12, lastAction: { type: 'Action Plan', date: '5/19/26, 4:42 PM' } },
+  { id: '3', firstName: 'Kerry', lastName: 'Leedy', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/14/26, 9:05 PM', loginCount: 7, actionCount: 3, lastAction: { type: 'Observation', date: '5/14/26, 9:05 PM' } },
+  { id: '4', firstName: 'Shonnell', lastName: 'Wilkins', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/17/26, 7:18 AM', loginCount: 5, actionCount: 2, lastAction: { type: 'Observation', date: '5/15/26, 10:22 AM' } },
+  { id: '5', firstName: 'Cassie', lastName: 'Sexton', role: 'teacher', program: 'Preschool Promise', status: 'active', lastLogin: '5/19/26, 2:48 PM', loginCount: 9, actionCount: 5, lastAction: { type: 'Training', date: '5/19/26, 3:00 PM' } },
+  { id: '6', firstName: 'Rene’e', lastName: 'Johnson', role: 'teacher', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/18/26, 11:02 AM', loginCount: 6, actionCount: 1, lastAction: { type: 'Observation', date: '5/12/26, 9:30 AM' } },
+  { id: '7', firstName: 'Nicole', lastName: 'Broomfield', role: 'teacher', program: 'Excel Prep Academy', status: 'active', lastLogin: '5/19/26, 4:14 PM', loginCount: 11, actionCount: 4, lastAction: { type: 'Conference Plan', date: '5/16/26, 1:48 PM' } },
+  { id: '8', firstName: 'Tyquaona', lastName: 'Montgomery', role: 'teacher', program: 'All Our Children Elite Childcare', status: 'active', lastLogin: '5/13/26, 8:01 AM', loginCount: 4, actionCount: 2, lastAction: { type: 'Email', date: '5/13/26, 10:11 AM' } },
+  { id: '9', firstName: 'Ann', lastName: 'James', role: 'teacher', program: 'Rex Childcare & Early Learning', status: 'active', lastLogin: 'Never', loginCount: 0, actionCount: 1, lastAction: { type: 'Observation', date: '5/11/26, 2:00 PM' } },
+  { id: '10', firstName: 'Michelle', lastName: 'Kreitzer', role: 'teacher', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/20/26, 7:42 AM', loginCount: 18, actionCount: 6, lastAction: { type: 'Conference Plan', date: '5/19/26, 11:30 AM' } },
+  { id: '11', firstName: 'Ciera', lastName: 'Davis', role: 'teacher', program: 'United Way', status: 'active', lastLogin: '5/16/26, 1:22 PM', loginCount: 3, actionCount: 1, lastAction: { type: 'Observation', date: '5/16/26, 2:45 PM' } },
+  { id: '12', firstName: 'Ja’Naye', lastName: 'Lattimore', role: 'teacher', program: 'United Way', status: 'active', lastLogin: '5/18/26, 9:55 AM', loginCount: 8, actionCount: 4, lastAction: { type: 'Training', date: '5/18/26, 10:30 AM' } },
+  { id: '13', firstName: 'Mitzi', lastName: 'Keesee', role: 'teacher', program: 'Excel Prep Academy', status: 'active', lastLogin: '5/15/26, 3:12 PM', loginCount: 6, actionCount: 2, lastAction: { type: 'Action Plan', date: '5/14/26, 4:22 PM' } },
+  { id: '14', firstName: 'Tina', lastName: 'Arnold', role: 'teacher', program: 'Preschool Promise', status: 'archived', lastLogin: '11/13/24, 1:20 PM', loginCount: 0, actionCount: 0, lastAction: { type: 'Email', date: '11/13/24, 1:20 PM' } },
+  { id: '15', firstName: 'Tisha', lastName: 'Owen', role: 'coach', program: 'Preschool Promise', status: 'active', lastLogin: '5/20/26, 7:01 AM', loginCount: 25, actionCount: 32, lastAction: { type: 'Observation', date: '5/20/26, 10:00 AM' } },
+  { id: '16', firstName: 'Dana', lastName: 'Al-Sarraj', role: 'coach', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/19/26, 4:30 PM', loginCount: 19, actionCount: 27, lastAction: { type: 'Conference Plan', date: '5/19/26, 5:00 PM' } },
+  { id: '17', firstName: 'Latara', lastName: 'Holt', role: 'coach', program: 'United Way', status: 'active', lastLogin: '5/20/26, 6:55 AM', loginCount: 21, actionCount: 24, lastAction: { type: 'Action Plan', date: '5/20/26, 9:14 AM' } },
+  { id: '18', firstName: 'Caroline', lastName: 'Christopher', role: 'admin', program: 'Vanderbilt Child and Family Center', status: 'active', lastLogin: '5/19/26, 11:10 AM', loginCount: 12, actionCount: 8, lastAction: { type: 'Email', date: '5/19/26, 11:20 AM' } },
+]
+
+const roleLabel: Record<TeacherRow['role'], string> = {
+  admin: 'Admin', programLeader: 'Program Leader', siteLeader: 'Site Leader',
+  coach: 'Coach', teacher: 'Teacher'
+}
+
+const FilterInput = (p: { placeholder: string; value?: string; width?: number }) => (
+  <input
+    placeholder={p.placeholder}
+    defaultValue={p.value}
+    style={{
+      width: p.width ?? 200,
+      padding: '0.55rem 0.95rem',
+      border: '1px solid var(--v2-line)',
+      borderRadius: 'var(--v2-radius-pill)',
+      fontSize: '0.85rem',
+      background: 'var(--v2-white)',
+      outline: 'none'
+    }}
+  />
+)
+
+const Select = (p: { children: React.ReactNode }) => (
+  <select style={{
+    padding: '0.55rem 0.95rem',
+    border: '1px solid var(--v2-line)',
+    borderRadius: 'var(--v2-radius-pill)',
+    fontSize: '0.85rem',
+    background: 'var(--v2-white)',
+    color: 'var(--v2-ink-soft)',
+    cursor: 'pointer'
+  }}>{p.children}</select>
+)
+
+const DateInput = (p: { value: string }) => (
+  <input
+    type="text"
+    defaultValue={p.value}
+    style={{
+      width: 120,
+      padding: '0.4rem 0.7rem',
+      border: '1px solid var(--v2-line)',
+      borderRadius: 'var(--v2-radius-sm)',
+      fontSize: '0.82rem',
+      background: 'var(--v2-white)',
+      color: 'var(--v2-ink)'
+    }}
+  />
+)
+
+const Preset = (p: { active?: boolean; children: React.ReactNode }) => (
+  <button style={{
+    padding: '0.4rem 0.75rem',
+    border: '1px solid var(--v2-line)',
+    borderRadius: 'var(--v2-radius-pill)',
+    background: p.active ? 'var(--v2-ink)' : 'var(--v2-white)',
+    color: p.active ? 'var(--v2-white)' : 'var(--v2-ink-soft)',
+    fontSize: '0.78rem', fontWeight: 600,
+    cursor: 'pointer'
+  }}>{p.children}</button>
+)
+
+export function AllTeachers() {
+  return (
+    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+        marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
+      }}>
+        <div>
+          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>All Teachers</h1>
+          <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+            {ROWS.length} teammates · login activity and recent action data
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Button>📥 Import CSV</Button>
+          <Button variant="primary">+ Add teammate</Button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div style={{
+        background: 'var(--v2-white)',
+        borderRadius: 'var(--v2-radius)',
+        padding: '1rem 1.25rem',
+        border: '1px solid var(--v2-line-soft)',
+        boxShadow: 'var(--v2-shadow-sm)',
+        marginBottom: '1rem',
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: '1rem',
+        alignItems: 'center'
+      }}>
+        <div style={{ display: 'flex', gap: '0.65rem', flexWrap: 'wrap', alignItems: 'center' }}>
+          <FilterInput placeholder="🔍 Search teachers, programs, sites…" />
+          <Select><option>All roles</option><option>Teacher</option><option>Coach</option></Select>
+          <Select><option>Active</option><option>Archived</option></Select>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'flex-end' }}>
+          <span style={{ fontSize: '0.82rem', color: 'var(--v2-muted)', fontWeight: 500 }}>Date range:</span>
+          <DateInput value="04/20/26" />
+          <span style={{ color: 'var(--v2-muted)' }}>→</span>
+          <DateInput value="05/20/26" />
+          <Preset>7d</Preset>
+          <Preset active>30d</Preset>
+          <Preset>90d</Preset>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div style={{
+        background: 'var(--v2-white)',
+        borderRadius: 'var(--v2-radius)',
+        border: '1px solid var(--v2-line-soft)',
+        boxShadow: 'var(--v2-shadow-sm)',
+        overflow: 'auto'
+      }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', borderSpacing: 0, minWidth: 1100 }}>
+          <thead>
+            <tr style={{ background: 'var(--v2-bg-soft)' }}>
+              {['Name', 'Role · Program', 'Status', 'Last Login', 'Login Count', 'Action Count', 'Last Action'].map((h, i) => (
+                <th key={i} style={{
+                  textAlign: 'left',
+                  padding: '0.85rem 1rem',
+                  fontSize: '0.7rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  color: 'var(--v2-muted)',
+                  borderBottom: '1px solid var(--v2-line)'
+                }}>
+                  {h}
+                  {(h === 'Login Count' || h === 'Action Count') && (
+                    <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>Apr 20 – May 20</div>
+                  )}
+                  {h === 'Last Action' && (
+                    <div style={{ fontWeight: 400, color: 'var(--v2-muted-soft)', fontSize: '0.7rem', textTransform: 'none', letterSpacing: 0, marginTop: '0.15rem' }}>all time</div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map(r => (
+              <tr key={r.id} style={{ borderBottom: '1px solid var(--v2-line-soft)' }}>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem' }}>
+                    <Avatar name={`${r.firstName} ${r.lastName}`} size={30} />
+                    <strong>{r.firstName} {r.lastName}</strong>
+                  </div>
+                </td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
+                  {roleLabel[r.role]} · {r.program}
+                </td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem' }}>
+                  <Pill variant={r.status === 'active' ? 'success' : 'neutral'}>
+                    {r.status === 'active' ? 'Active' : 'Archived'}
+                  </Pill>
+                </td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>{r.lastLogin}</td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>{r.loginCount}</td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', fontWeight: 700, textAlign: 'right' }}>
+                  <span style={{ borderBottom: r.actionCount > 0 ? '1px dotted var(--v2-muted-soft)' : 'none', cursor: 'help' }}>
+                    {r.actionCount}
+                  </span>
+                </td>
+                <td style={{ padding: '0.85rem 1rem', fontSize: '0.88rem', color: 'var(--v2-ink-soft)' }}>
+                  {r.lastAction.type} — {r.lastAction.date}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: '1rem', fontSize: '0.82rem', color: 'var(--v2-muted)', textAlign: 'center' }}>
+        Showing 1-{ROWS.length} of {ROWS.length} records
+      </div>
+    </div>
+  )
+}

--- a/src/v2/pages/AllTeachers.tsx
+++ b/src/v2/pages/AllTeachers.tsx
@@ -217,7 +217,7 @@ export function AllTeachers() {
   }
 
   return (
-    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+    <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       {/* Header */}
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',

--- a/src/v2/pages/CoachHome.tsx
+++ b/src/v2/pages/CoachHome.tsx
@@ -2,47 +2,39 @@ import * as React from 'react'
 import { Avatar } from '../components/Avatar'
 import { Button } from '../components/Button'
 import { Card, CardHeader } from '../components/Card'
+import { EmptyState } from '../components/EmptyState'
 import { Pill } from '../components/Pill'
 import { Stat } from '../components/Stat'
+import { StatSkeleton } from '../components/Skeleton'
+import { useV2Auth } from '../hooks/useV2Auth'
+import { useV2Firebase } from '../lib/firebase'
+import { createV2Api } from '../lib/api'
+import { ActivityItem, AttentionItem, DashboardStats, PlanItem } from '../lib/types'
 
-type AttentionTeacher = {
-  id: string
-  name: string
-  reason: { text: string; variant: 'warn' | 'danger' | 'neutral' }
-  context: string
-  cta: string
+const EMPTY_STATS: DashboardStats = {
+  underCoaching: 12,
+  needAttention: 4,
+  observationsThisWeek: 8,
+  activePlans: 6
 }
 
-type ActivityItem = {
-  title: string
-  meta: string
-  tone: 'success' | 'brand' | 'warn'
-}
-
-type PlanItem = {
-  title: string
-  forName: string
-  progress: number
-  due: string
-}
-
-const STUB_ATTENTION: AttentionTeacher[] = [
-  { id: 'dj', name: 'Dawn Johnson', reason: { text: 'No observation in 45d', variant: 'danger' }, context: 'Pre-K · Preschool Promise', cta: 'Schedule obs' },
-  { id: 'cg', name: 'Chrystaline Glenn', reason: { text: 'Action plan overdue', variant: 'warn' }, context: 'Toddler · All Our Children Elite', cta: 'Open plan' },
-  { id: 'kl', name: 'Kerry Leedy', reason: { text: 'Magic 9 score dropped', variant: 'warn' }, context: 'Pre-K · Preschool Promise', cta: 'Send check-in' },
-  { id: 'sw', name: 'Shonnell Wilkins', reason: { text: 'No activity recently', variant: 'neutral' }, context: 'Infant · All Our Children Elite', cta: 'Send check-in' }
+const STUB_ATTENTION: AttentionItem[] = [
+  { id: 'demo-teacher-1', name: 'Alex Rivera', reason: { text: 'No observation in 45d', variant: 'danger' }, context: 'Pre-K · Demo Early Learning', cta: 'Schedule obs' },
+  { id: 'demo-teacher-2', name: 'Morgan Lee', reason: { text: 'Action plan overdue', variant: 'warn' }, context: 'Toddler · River Center Demo', cta: 'Open plan' },
+  { id: 'demo-teacher-3', name: 'Jamie Chen', reason: { text: 'Magic 9 score dropped', variant: 'warn' }, context: 'Pre-K · Demo Early Learning', cta: 'Send check-in' },
+  { id: 'demo-teacher-4', name: 'Sam Taylor', reason: { text: 'No activity recently', variant: 'neutral' }, context: 'Infant · River Center Demo', cta: 'Send check-in' }
 ]
 
 const STUB_ACTIVITY: ActivityItem[] = [
-  { title: 'Observation completed', meta: 'Chrystaline Glenn · 22 min ago', tone: 'success' },
-  { title: 'Note sent to teacher', meta: 'Dawn Johnson · 1h ago', tone: 'brand' },
-  { title: 'Action plan flagged overdue', meta: 'Chrystaline Glenn · 3h ago', tone: 'warn' },
-  { title: 'Training completed', meta: 'Kerry Leedy · Classroom Climate · Yesterday', tone: 'success' }
+  { id: 'a1', title: 'Observation completed', meta: 'Morgan Lee · 22 min ago', tone: 'success' },
+  { id: 'a2', title: 'Note sent to teacher', meta: 'Alex Rivera · 1h ago', tone: 'brand' },
+  { id: 'a3', title: 'Action plan flagged overdue', meta: 'Morgan Lee · 3h ago', tone: 'warn' },
+  { id: 'a4', title: 'Training completed', meta: 'Jamie Chen · Classroom Climate · Yesterday', tone: 'success' }
 ]
 
 const STUB_PLANS: PlanItem[] = [
-  { title: 'Reducing transition time', forName: 'Chrystaline G.', progress: 65, due: 'Due May 28' },
-  { title: 'Open-ended questions', forName: 'Dawn J.', progress: 30, due: 'Due Jun 3' }
+  { id: 'p1', title: 'Reducing transition time', forName: 'Morgan L.', progress: 65, due: 'Due May 28' },
+  { id: 'p2', title: 'Open-ended questions', forName: 'Alex R.', progress: 30, due: 'Due Jun 3' }
 ]
 
 function TimelineItem(props: ActivityItem) {
@@ -84,7 +76,7 @@ function PlanMini(props: PlanItem) {
   )
 }
 
-function AttentionRow(props: { teacher: AttentionTeacher }) {
+function AttentionRow(props: { teacher: AttentionItem }) {
   const t = props.teacher
   return (
     <div style={{
@@ -106,11 +98,50 @@ function AttentionRow(props: { teacher: AttentionTeacher }) {
 }
 
 export function CoachHome(props: { userName: string; programCount?: number }) {
-  const firstName = props.userName.split(' ')[0]
+  const firebase = useV2Firebase()
+  const auth = useV2Auth()
+  const [stats, setStats] = React.useState<DashboardStats>(EMPTY_STATS)
+  const [attention, setAttention] = React.useState<AttentionItem[]>(STUB_ATTENTION)
+  const [activity, setActivity] = React.useState<ActivityItem[]>(STUB_ACTIVITY)
+  const [plans, setPlans] = React.useState<PlanItem[]>(STUB_PLANS)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+
+  React.useEffect(() => {
+    if (!auth.user) {
+      return
+    }
+
+    let active = true
+    const api = createV2Api(firebase)
+    setLoading(true)
+    setError(null)
+
+    Promise.all([
+      api.getDashboardStats(auth.user.uid),
+      api.getCoachAttention(auth.user.uid),
+      api.getRecentActivity(auth.user.uid),
+      api.getActivePlans(auth.user.uid)
+    ]).then(([nextStats, nextAttention, nextActivity, nextPlans]) => {
+      if (!active) return
+      setStats(nextStats)
+      setAttention(nextAttention.length > 0 ? nextAttention : [])
+      setActivity(nextActivity.length > 0 ? nextActivity : [])
+      setPlans(nextPlans.length > 0 ? nextPlans : [])
+      setLoading(false)
+    }).catch(fetchError => {
+      if (!active) return
+      setError(fetchError as Error)
+      setLoading(false)
+    })
+
+    return () => { active = false }
+  }, [auth.user, firebase])
+
+  const firstName = auth.user?.firstName || props.userName.split(' ')[0]
 
   return (
     <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
-      {/* Greeting */}
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end',
         marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
@@ -120,7 +151,7 @@ export function CoachHome(props: { userName: string; programCount?: number }) {
             Good morning, <span style={{ color: 'var(--v2-brand)', fontWeight: 800 }}>{firstName}</span>
           </h1>
           <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
-            You have 3 observations scheduled today and 2 teachers flagged for follow-up.
+            {stats.observationsThisWeek} observations this week and {stats.needAttention} teachers flagged for follow-up.
           </div>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
@@ -129,33 +160,47 @@ export function CoachHome(props: { userName: string; programCount?: number }) {
         </div>
       </div>
 
-      {/* Stats */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
-        <Stat tone="brand" icon="👥" label="Under coaching" value="12" delta={{ text: 'No change this week', trend: 'flat' }} />
-        <Stat tone="warm" icon="⚠" label="Need attention" value="4" delta={{ text: '↑ 2 since last week', trend: 'warn' }} />
-        <Stat tone="success" icon="✓" label="Observations this week" value="8" delta={{ text: '↑ 33% vs avg', trend: 'up' }} />
-        <Stat tone="gold" icon="📋" label="Action plans active" value="6" delta={{ text: '2 due Friday', trend: 'up' }} />
-      </div>
+      {loading ? (
+        <StatSkeleton />
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: '1rem', marginBottom: '1.5rem' }}>
+          <Stat tone="brand" icon="👥" label="Under coaching" value={String(stats.underCoaching)} delta={{ text: 'Active teacher links', trend: 'flat' }} />
+          <Stat tone="warm" icon="⚠" label="Need attention" value={String(stats.needAttention)} delta={{ text: 'Derived from activity', trend: stats.needAttention > 0 ? 'warn' : 'flat' }} />
+          <Stat tone="success" icon="✓" label="Observations this week" value={String(stats.observationsThisWeek)} delta={{ text: 'Live Firestore count', trend: 'up' }} />
+          <Stat tone="gold" icon="📋" label="Action plans active" value={String(stats.activePlans)} delta={{ text: 'Open plan count', trend: 'up' }} />
+        </div>
+      )}
 
-      {/* Two-column grid */}
-      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '1rem' }}>
+      {error && (
+        <Card style={{ marginBottom: '1rem', borderColor: 'var(--v2-warm)' }}>
+          <div style={{ color: 'var(--v2-warm-dark)', fontWeight: 600 }}>Unable to load live dashboard data.</div>
+        </Card>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '1rem' }}>
         <Card>
           <CardHeader
-            title={<>Teachers needing attention <Pill variant="warn" style={{ background: 'var(--v2-warm)', color: '#fff' }}>4</Pill></>}
+            title={<>Teachers needing attention <Pill variant="warn" style={{ background: 'var(--v2-warm)', color: '#fff' }}>{attention.length}</Pill></>}
             action="View all teachers →"
           />
-          {STUB_ATTENTION.map(t => <AttentionRow key={t.id} teacher={t} />)}
+          {attention.length > 0 ? attention.map(t => <AttentionRow key={t.id} teacher={t} />) : (
+            <EmptyState title="No teachers need attention" description="The current data range has no flagged teachers." />
+          )}
         </Card>
 
         <div>
           <Card style={{ marginBottom: '1rem' }}>
             <CardHeader title="Recent activity" action="All →" />
-            {STUB_ACTIVITY.map((a, i) => <TimelineItem key={i} {...a} />)}
+            {activity.length > 0 ? activity.map(a => <TimelineItem key={a.id} {...a} />) : (
+              <EmptyState title="No recent activity" description="Recent observations, plans, emails, and training events will appear here." />
+            )}
           </Card>
 
           <Card>
             <CardHeader title="Active action plans" />
-            {STUB_PLANS.map((p, i) => <PlanMini key={i} {...p} />)}
+            {plans.length > 0 ? plans.map(p => <PlanMini key={p.id} {...p} />) : (
+              <EmptyState title="No active plans" description="Open action plans will appear here after they are created." />
+            )}
           </Card>
         </div>
       </div>

--- a/src/v2/pages/CoachHome.tsx
+++ b/src/v2/pages/CoachHome.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react'
+import { Avatar } from '../components/Avatar'
+import { Button } from '../components/Button'
+import { Card, CardHeader } from '../components/Card'
+import { Pill } from '../components/Pill'
+import { Stat } from '../components/Stat'
+
+type AttentionTeacher = {
+  id: string
+  name: string
+  reason: { text: string; variant: 'warn' | 'danger' | 'neutral' }
+  context: string
+  cta: string
+}
+
+type ActivityItem = {
+  title: string
+  meta: string
+  tone: 'success' | 'brand' | 'warn'
+}
+
+type PlanItem = {
+  title: string
+  forName: string
+  progress: number
+  due: string
+}
+
+const STUB_ATTENTION: AttentionTeacher[] = [
+  { id: 'dj', name: 'Dawn Johnson', reason: { text: 'No observation in 45d', variant: 'danger' }, context: 'Pre-K · Preschool Promise', cta: 'Schedule obs' },
+  { id: 'cg', name: 'Chrystaline Glenn', reason: { text: 'Action plan overdue', variant: 'warn' }, context: 'Toddler · All Our Children Elite', cta: 'Open plan' },
+  { id: 'kl', name: 'Kerry Leedy', reason: { text: 'Magic 9 score dropped', variant: 'warn' }, context: 'Pre-K · Preschool Promise', cta: 'Send check-in' },
+  { id: 'sw', name: 'Shonnell Wilkins', reason: { text: 'No activity recently', variant: 'neutral' }, context: 'Infant · All Our Children Elite', cta: 'Send check-in' }
+]
+
+const STUB_ACTIVITY: ActivityItem[] = [
+  { title: 'Observation completed', meta: 'Chrystaline Glenn · 22 min ago', tone: 'success' },
+  { title: 'Note sent to teacher', meta: 'Dawn Johnson · 1h ago', tone: 'brand' },
+  { title: 'Action plan flagged overdue', meta: 'Chrystaline Glenn · 3h ago', tone: 'warn' },
+  { title: 'Training completed', meta: 'Kerry Leedy · Classroom Climate · Yesterday', tone: 'success' }
+]
+
+const STUB_PLANS: PlanItem[] = [
+  { title: 'Reducing transition time', forName: 'Chrystaline G.', progress: 65, due: 'Due May 28' },
+  { title: 'Open-ended questions', forName: 'Dawn J.', progress: 30, due: 'Due Jun 3' }
+]
+
+function TimelineItem(props: ActivityItem) {
+  const dot = props.tone === 'success' ? 'var(--v2-success)' : props.tone === 'warn' ? 'var(--v2-warm)' : 'var(--v2-brand)'
+  return (
+    <div style={{
+      position: 'relative',
+      padding: '0.4rem 0 0.85rem 1.55rem',
+      borderLeft: '2px solid var(--v2-line)',
+      marginLeft: '0.5rem'
+    }}>
+      <span style={{
+        position: 'absolute', left: -8, top: '0.7rem',
+        width: 14, height: 14, borderRadius: '50%',
+        background: dot,
+        border: '3px solid var(--v2-white)',
+        boxShadow: `0 0 0 1px ${dot}`
+      }} />
+      <div style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--v2-ink)' }}>{props.title}</div>
+      <div style={{ fontSize: '0.75rem', color: 'var(--v2-muted)', marginTop: '0.1rem' }}>{props.meta}</div>
+    </div>
+  )
+}
+
+function PlanMini(props: PlanItem) {
+  return (
+    <div style={{ padding: '0.85rem', background: 'var(--v2-bg-soft)', borderRadius: 10, marginBottom: '0.6rem' }}>
+      <div style={{ fontSize: '0.85rem', fontWeight: 600, display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.45rem' }}>
+        <span>{props.title}</span>
+        <span style={{ color: 'var(--v2-muted)', fontWeight: 400, fontSize: '0.78rem' }}>{props.forName}</span>
+      </div>
+      <div style={{ height: 6, background: 'var(--v2-white)', borderRadius: 999, overflow: 'hidden' }}>
+        <div style={{ height: '100%', width: `${props.progress}%`, background: 'var(--v2-brand)', borderRadius: 999 }} />
+      </div>
+      <div style={{ fontSize: '0.72rem', color: 'var(--v2-muted)', marginTop: '0.4rem', display: 'flex', justifyContent: 'space-between' }}>
+        <span>{props.progress}% complete</span><span>{props.due}</span>
+      </div>
+    </div>
+  )
+}
+
+function AttentionRow(props: { teacher: AttentionTeacher }) {
+  const t = props.teacher
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: '0.85rem',
+      padding: '0.85rem 0',
+      borderBottom: '1px solid var(--v2-line-soft)'
+    }}>
+      <Avatar name={t.name} size={38} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600, fontSize: '0.9rem' }}>{t.name}</div>
+        <div style={{ fontSize: '0.76rem', color: 'var(--v2-muted)', marginTop: '0.1rem' }}>
+          <Pill variant={t.reason.variant} style={{ marginRight: '0.35rem' }}>{t.reason.text}</Pill>
+          {t.context}
+        </div>
+      </div>
+      <Button size="sm">{t.cta}</Button>
+    </div>
+  )
+}
+
+export function CoachHome(props: { userName: string; programCount?: number }) {
+  const firstName = props.userName.split(' ')[0]
+
+  return (
+    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      {/* Greeting */}
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end',
+        marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
+      }}>
+        <div>
+          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>
+            Good morning, <span style={{ color: 'var(--v2-brand)', fontWeight: 800 }}>{firstName}</span>
+          </h1>
+          <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+            You have 3 observations scheduled today and 2 teachers flagged for follow-up.
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Button>📅 Schedule</Button>
+          <Button variant="accent">▶ Start observation</Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
+        <Stat tone="brand" icon="👥" label="Under coaching" value="12" delta={{ text: 'No change this week', trend: 'flat' }} />
+        <Stat tone="warm" icon="⚠" label="Need attention" value="4" delta={{ text: '↑ 2 since last week', trend: 'warn' }} />
+        <Stat tone="success" icon="✓" label="Observations this week" value="8" delta={{ text: '↑ 33% vs avg', trend: 'up' }} />
+        <Stat tone="gold" icon="📋" label="Action plans active" value="6" delta={{ text: '2 due Friday', trend: 'up' }} />
+      </div>
+
+      {/* Two-column grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '1rem' }}>
+        <Card>
+          <CardHeader
+            title={<>Teachers needing attention <Pill variant="warn" style={{ background: 'var(--v2-warm)', color: '#fff' }}>4</Pill></>}
+            action="View all teachers →"
+          />
+          {STUB_ATTENTION.map(t => <AttentionRow key={t.id} teacher={t} />)}
+        </Card>
+
+        <div>
+          <Card style={{ marginBottom: '1rem' }}>
+            <CardHeader title="Recent activity" action="All →" />
+            {STUB_ACTIVITY.map((a, i) => <TimelineItem key={i} {...a} />)}
+          </Card>
+
+          <Card>
+            <CardHeader title="Active action plans" />
+            {STUB_PLANS.map((p, i) => <PlanMini key={i} {...p} />)}
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/v2/pages/CoachHome.tsx
+++ b/src/v2/pages/CoachHome.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useHistory } from 'react-router-dom'
 import { Avatar } from '../components/Avatar'
 import { Button } from '../components/Button'
 import { Card, CardHeader } from '../components/Card'
@@ -6,6 +7,7 @@ import { EmptyState } from '../components/EmptyState'
 import { Pill } from '../components/Pill'
 import { Stat } from '../components/Stat'
 import { StatSkeleton } from '../components/Skeleton'
+import { useToast } from '../hooks/useToast'
 import { useV2Auth } from '../hooks/useV2Auth'
 import { useV2Firebase } from '../lib/firebase'
 import { createV2Api } from '../lib/api'
@@ -76,7 +78,7 @@ function PlanMini(props: PlanItem) {
   )
 }
 
-function AttentionRow(props: { teacher: AttentionItem }) {
+function AttentionRow(props: { teacher: AttentionItem; onAction(teacher: AttentionItem): void }) {
   const t = props.teacher
   return (
     <div style={{
@@ -92,7 +94,7 @@ function AttentionRow(props: { teacher: AttentionItem }) {
           {t.context}
         </div>
       </div>
-      <Button size="sm">{t.cta}</Button>
+      <Button size="sm" onClick={() => props.onAction(t)}>{t.cta}</Button>
     </div>
   )
 }
@@ -100,6 +102,8 @@ function AttentionRow(props: { teacher: AttentionItem }) {
 export function CoachHome(props: { userName: string; programCount?: number }) {
   const firebase = useV2Firebase()
   const auth = useV2Auth()
+  const history = useHistory()
+  const toast = useToast()
   const [stats, setStats] = React.useState<DashboardStats>(EMPTY_STATS)
   const [attention, setAttention] = React.useState<AttentionItem[]>(STUB_ATTENTION)
   const [activity, setActivity] = React.useState<ActivityItem[]>(STUB_ACTIVITY)
@@ -140,8 +144,31 @@ export function CoachHome(props: { userName: string; programCount?: number }) {
 
   const firstName = auth.user?.firstName || props.userName.split(' ')[0]
 
+  const openObservation = (teacher?: AttentionItem) => {
+    if (!teacher) {
+      history.push('/v2/observation')
+      return
+    }
+
+    history.push(`/v2/observation?teacher=${encodeURIComponent(teacher.id)}&teacherName=${encodeURIComponent(teacher.name)}&classroom=${encodeURIComponent(teacher.context)}&session=Coaching check-in`)
+  }
+
+  const openAttentionAction = (teacher: AttentionItem) => {
+    const cta = teacher.cta.toLowerCase()
+    if (cta.includes('obs') || cta.includes('schedule')) {
+      openObservation(teacher)
+      return
+    }
+    if (cta.includes('plan')) {
+      history.push('/v2/plans')
+      return
+    }
+    toast.info('Teacher profile detail remains in legacy CHALK for this sprint.')
+    history.push('/v2/teachers')
+  }
+
   return (
-    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+    <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end',
         marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
@@ -155,8 +182,8 @@ export function CoachHome(props: { userName: string; programCount?: number }) {
           </div>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <Button>📅 Schedule</Button>
-          <Button variant="accent">▶ Start observation</Button>
+          <Button onClick={() => { toast.info('Choose a teacher, then schedule from the teacher workflow.'); history.push('/v2/teachers') }}>📅 Schedule</Button>
+          <Button variant="accent" onClick={() => openObservation()}>▶ Start observation</Button>
         </div>
       </div>
 
@@ -181,16 +208,16 @@ export function CoachHome(props: { userName: string; programCount?: number }) {
         <Card>
           <CardHeader
             title={<>Teachers needing attention <Pill variant="warn" style={{ background: 'var(--v2-warm)', color: '#fff' }}>{attention.length}</Pill></>}
-            action="View all teachers →"
+            action={<button type="button" onClick={() => history.push('/v2/teachers')} style={{ color: 'var(--v2-brand-dark)', fontWeight: 600, padding: 0 }}>View all teachers →</button>}
           />
-          {attention.length > 0 ? attention.map(t => <AttentionRow key={t.id} teacher={t} />) : (
+          {attention.length > 0 ? attention.map(t => <AttentionRow key={t.id} teacher={t} onAction={openAttentionAction} />) : (
             <EmptyState title="No teachers need attention" description="The current data range has no flagged teachers." />
           )}
         </Card>
 
         <div>
           <Card style={{ marginBottom: '1rem' }}>
-            <CardHeader title="Recent activity" action="All →" />
+            <CardHeader title="Recent activity" action={<button type="button" onClick={() => history.push('/v2/teachers')} style={{ color: 'var(--v2-brand-dark)', fontWeight: 600, padding: 0 }}>All →</button>} />
             {activity.length > 0 ? activity.map(a => <TimelineItem key={a.id} {...a} />) : (
               <EmptyState title="No recent activity" description="Recent observations, plans, emails, and training events will appear here." />
             )}

--- a/src/v2/pages/LiveObservation.tsx
+++ b/src/v2/pages/LiveObservation.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
 import { Button } from '../components/Button'
 import { Card } from '../components/Card'
+import { useToast } from '../hooks/useToast'
+import { useV2Auth } from '../hooks/useV2Auth'
+import { useV2Firebase } from '../lib/firebase'
+import { createV2Api } from '../lib/api'
+import { OBSERVATION_TYPE_OPTIONS, getObservationTypeOption, getStoredObservationType } from '../lib/observationTypes'
 
 const TAGS = ['Listening', 'Sequential', 'Math', 'Literacy', 'SEL', 'Engagement', 'Transitions', 'Climate', 'Instruction']
 
@@ -66,19 +72,206 @@ function Tag(p: { children: React.ReactNode }) {
   }}>{p.children}</span>
 }
 
+function formatElapsed(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
 export function LiveObservation() {
+  const history = useHistory()
+  const location = useLocation()
+  const firebase = useV2Firebase()
+  const auth = useV2Auth()
+  const toast = useToast()
+  const params = new URLSearchParams(location.search)
+  const selectedCode = params.get('type')
+  const teacherUid = params.get('teacher') || 'demo-teacher-1'
+  const teacherName = params.get('teacherName') || 'Alex Rivera'
+  const classroomName = params.get('classroom') || 'Demo Early Learning - Pre-K'
+  const sessionName = params.get('session') || 'Morning circle'
+  const selectedOption = getObservationTypeOption(selectedCode)
+  const storedObservationType = getStoredObservationType(selectedCode)
+  const [elapsedSeconds, setElapsedSeconds] = React.useState(0)
+  const [notes, setNotes] = React.useState('')
+  const [draftStatus, setDraftStatus] = React.useState('Ready')
+  const [paused, setPaused] = React.useState(false)
+  const startedRef = React.useRef(false)
+
+  const selectObservationType = (code: string) => {
+    const next = new URLSearchParams(location.search)
+    if (!next.get('teacher')) {
+      next.set('teacher', teacherUid)
+    }
+    if (!next.get('teacherName')) {
+      next.set('teacherName', teacherName)
+    }
+    if (!next.get('classroom')) {
+      next.set('classroom', classroomName)
+    }
+    if (!next.get('session')) {
+      next.set('session', sessionName)
+    }
+    next.set('type', code)
+    history.push({ pathname: location.pathname, search: `?${next.toString()}` })
+  }
+
+  const startNewObservation = () => {
+    history.push({
+      pathname: '/v2/observation',
+      search: `?teacher=${encodeURIComponent(teacherUid)}&teacherName=${encodeURIComponent(teacherName)}&classroom=${encodeURIComponent(classroomName)}&session=${encodeURIComponent(sessionName)}`
+    })
+  }
+
+  React.useEffect(() => {
+    if (!selectedOption || paused) {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      setElapsedSeconds(current => current + 1)
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [paused, selectedOption])
+
+  React.useEffect(() => {
+    if (!selectedOption || !storedObservationType || !auth.user || startedRef.current) {
+      return
+    }
+
+    startedRef.current = true
+    createV2Api(firebase).startObservation(auth.user.uid, teacherUid, selectedOption.code).catch(error => {
+      console.error('Unable to start v2 observation session', error)
+      startedRef.current = false
+    })
+  }, [auth.user, firebase, selectedOption, storedObservationType, teacherUid])
+
+  React.useEffect(() => {
+    if (!selectedOption || !storedObservationType) {
+      return
+    }
+
+    setDraftStatus('Saving...')
+    const timeout = window.setTimeout(() => {
+      const draft = {
+        teacherUid,
+        typeCode: selectedOption.code,
+        storedType: storedObservationType,
+        notes,
+        elapsedSeconds,
+        updatedAt: new Date()
+      }
+
+      window.localStorage.setItem('chalk-v2-observation-draft', JSON.stringify(draft))
+
+      if (!auth.user) {
+        setDraftStatus('Saved locally')
+        return
+      }
+
+      firebase.db.collection('users').doc(auth.user.uid).set({ observationDraft: draft }, { merge: true })
+        .then(() => setDraftStatus('Auto-saved'))
+        .catch(error => {
+          console.error('Unable to save v2 observation draft', error)
+          setDraftStatus('Saved locally')
+        })
+    }, 900)
+
+    return () => window.clearTimeout(timeout)
+  }, [auth.user, elapsedSeconds, firebase, notes, selectedOption, storedObservationType, teacherUid])
+
+  const insertTag = (tag: string) => {
+    setNotes(current => `${current}${current ? '\n' : ''}[${formatElapsed(elapsedSeconds)}] ${tag}: `)
+    toast.info(`${tag} tag added to notes.`)
+  }
+
+  const endObservation = () => {
+    if (!auth.user) {
+      toast.info('Observation draft saved locally for preview.')
+      return
+    }
+
+    createV2Api(firebase).endObservation()
+      .then(() => toast.success('Observation completed.'))
+      .catch(error => {
+        console.error('Unable to end v2 observation', error)
+        toast.error('Unable to complete observation.')
+      })
+  }
+
+  if (!selectedOption || !storedObservationType) {
+    return (
+      <div style={{ padding: '2rem 2.5rem', maxWidth: 1100, margin: '0 auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '1rem' }}>
+          <div>
+            <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Pick what you're observing</h1>
+            <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+              Choose one of the legacy-compatible CHALK observation types before starting a session.
+            </div>
+          </div>
+          <Button onClick={() => history.push('/v2/home')}>Cancel</Button>
+        </div>
+
+        <Card>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: '0.8rem' }}>
+            {OBSERVATION_TYPE_OPTIONS.map(option => (
+              <button
+                key={option.code}
+                type="button"
+                onClick={() => selectObservationType(option.code)}
+                style={{
+                  textAlign: 'left',
+                  background: 'var(--v2-white)',
+                  border: '1px solid var(--v2-line)',
+                  borderRadius: 8,
+                  padding: '1rem',
+                  cursor: 'pointer',
+                  boxShadow: 'var(--v2-shadow-sm)'
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.45rem' }}>
+                  <span style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 34,
+                    height: 28,
+                    background: 'var(--v2-brand-soft)',
+                    color: 'var(--v2-brand-darker)',
+                    borderRadius: 6,
+                    fontSize: '0.75rem',
+                    fontWeight: 800
+                  }}>{option.code}</span>
+                  <strong style={{ color: 'var(--v2-ink)', fontSize: '0.92rem' }}>{option.label}</strong>
+                </div>
+                <p style={{ color: 'var(--v2-muted)', fontSize: '0.82rem', lineHeight: 1.45, margin: 0 }}>{option.description}</p>
+                <div style={{ color: 'var(--v2-ink-soft)', fontSize: '0.74rem', marginTop: '0.7rem', fontWeight: 600 }}>
+                  Stores as: {option.storedType}{option.requiresChecklist ? ' + checklist' : ''}
+                </div>
+              </button>
+            ))}
+          </div>
+        </Card>
+      </div>
+    )
+  }
+
   return (
     <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
           <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>
-            Live observation — <span style={{ color: 'var(--v2-brand)', fontWeight: 800 }}>Dawn Johnson</span>
+            Live observation — <span style={{ color: 'var(--v2-brand)', fontWeight: 800 }}>{teacherName}</span>
           </h1>
           <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
-            Preschool Promise · Pre-K Room · Morning circle session
+            {classroomName} · {sessionName} session
+          </div>
+          <div style={{ color: 'var(--v2-ink-soft)', fontSize: '0.78rem', marginTop: '0.45rem', fontWeight: 600 }}>
+            Observation type: {selectedOption.code} stores as {storedObservationType}{selectedOption.requiresChecklist ? ' + checklist' : ''}
           </div>
         </div>
-        <Button>Cancel</Button>
+        <Button onClick={() => history.push('/v2/home')}>Cancel</Button>
       </div>
 
       {/* Mode tabs + auto-save */}
@@ -110,12 +303,12 @@ export function LiveObservation() {
             width: 8, height: 8, background: 'var(--v2-success)', borderRadius: '50%',
             display: 'inline-block'
           }} />
-          Auto-saved · 4s ago
+          {draftStatus}
         </span>
       </div>
 
       {/* Main grid */}
-      <div style={{ display: 'grid', gridTemplateColumns: '2.5fr 1fr', gap: '1rem' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '1rem' }}>
         <Card>
           {/* Context */}
           <div style={{
@@ -127,19 +320,19 @@ export function LiveObservation() {
           }}>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Teacher</div>
-              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Dawn Johnson</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{teacherName}</div>
             </div>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Classroom</div>
-              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Preschool Promise — Pre-K</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{classroomName}</div>
             </div>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Session</div>
-              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Morning circle</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{sessionName}</div>
             </div>
             <div style={{ flex: 1, textAlign: 'right' }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Elapsed</div>
-              <div style={{ fontFamily: 'SF Mono, monospace', fontSize: '2.1rem', fontWeight: 700, color: 'var(--v2-brand)', letterSpacing: '-0.03em', lineHeight: 1 }}>14:32</div>
+              <div style={{ fontFamily: 'SF Mono, monospace', fontSize: '2.1rem', fontWeight: 700, color: 'var(--v2-brand)', letterSpacing: '-0.03em', lineHeight: 1 }}>{formatElapsed(elapsedSeconds)}</div>
             </div>
           </div>
 
@@ -160,15 +353,32 @@ export function LiveObservation() {
             <p style={{ marginBottom: '0.8rem' }}><Ts>09:10</Ts>Reading time. Voice modulation strong. Pacing held attention.</p>
             <p style={{ marginBottom: '0.8rem' }}><Ts>12:30</Ts>Center cleanup → next activity. Better than transition #1, used a song to cue.</p>
             <p style={{ color: 'var(--v2-muted)', fontStyle: 'italic' }}>Keep typing — auto-saving as you go.</p>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.currentTarget.value)}
+              placeholder="Add live observation notes..."
+              style={{
+                width: '100%',
+                minHeight: 130,
+                marginTop: '1rem',
+                border: '1px solid var(--v2-line)',
+                borderRadius: 8,
+                padding: '0.9rem',
+                background: 'var(--v2-white)',
+                resize: 'vertical',
+                lineHeight: 1.55
+              }}
+            />
           </div>
 
           <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.1rem', paddingTop: '1.1rem', borderTop: '1px solid var(--v2-line)' }}>
-            <Button>📸 Photo</Button>
-            <Button>🎙 Audio</Button>
-            <Button>🏷 Tag</Button>
-            <Button>⏸ Pause</Button>
+            <Button onClick={() => toast.info('Photo capture is outside this release; attach evidence in legacy CHALK for now.')}>📸 Photo</Button>
+            <Button onClick={() => toast.info('Audio capture is outside this release; use written notes for this sprint.')}>🎙 Audio</Button>
+            <Button onClick={() => insertTag(selectedOption.label)}>🏷 Tag</Button>
+            <Button onClick={startNewObservation}>Switch type</Button>
+            <Button onClick={() => setPaused(current => !current)}>{paused ? '▶ Resume' : '⏸ Pause'}</Button>
             <div style={{ flex: 1 }} />
-            <Button variant="primary">End &amp; align to framework →</Button>
+            <Button variant="primary" onClick={endObservation}>End &amp; align to framework →</Button>
           </div>
         </Card>
 
@@ -177,7 +387,7 @@ export function LiveObservation() {
           <Card padding="1.15rem">
             <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>🎯 Magic 9 quick tags</h4>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
-              {TAGS.map(t => <Chip key={t}>{t}</Chip>)}
+              {TAGS.map(t => <button key={t} type="button" onClick={() => insertTag(t)} style={{ border: 'none', padding: 0, background: 'transparent' }}><Chip>{t}</Chip></button>)}
             </div>
           </Card>
 

--- a/src/v2/pages/LiveObservation.tsx
+++ b/src/v2/pages/LiveObservation.tsx
@@ -31,16 +31,16 @@ function Tab(p: { active?: boolean; isNew?: boolean; children: React.ReactNode }
   )
 }
 
-function Chip(p: { children: React.ReactNode }) {
+function Chip(p: { children: React.ReactNode; active?: boolean }) {
   return (
     <span style={{
-      background: 'var(--v2-bg-soft)',
+      background: p.active ? 'var(--v2-ink)' : 'var(--v2-bg-soft)',
       border: '1px solid var(--v2-line)',
       padding: '0.25rem 0.65rem',
       borderRadius: 'var(--v2-radius-pill)',
       fontSize: '0.76rem',
       fontWeight: 500,
-      color: 'var(--v2-ink-soft)',
+      color: p.active ? 'var(--v2-white)' : 'var(--v2-ink-soft)',
       cursor: 'pointer'
     }}>{p.children}</span>
   )
@@ -78,6 +78,11 @@ function formatElapsed(totalSeconds: number): string {
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
 }
 
+function appendTimestamp(current: string, elapsedSeconds: number, label: string = ''): string {
+  const prefix = `[${formatElapsed(elapsedSeconds)}]${label ? ` ${label}:` : ''} `
+  return `${current}${current ? '\n' : ''}${prefix}`
+}
+
 export function LiveObservation() {
   const history = useHistory()
   const location = useLocation()
@@ -96,6 +101,12 @@ export function LiveObservation() {
   const [notes, setNotes] = React.useState('')
   const [draftStatus, setDraftStatus] = React.useState('Ready')
   const [paused, setPaused] = React.useState(false)
+  const [alignmentOpen, setAlignmentOpen] = React.useState(false)
+  const [alignedTags, setAlignedTags] = React.useState<string[]>(['Transitions'])
+  const [strength, setStrength] = React.useState('')
+  const [opportunity, setOpportunity] = React.useState('')
+  const [nextStep, setNextStep] = React.useState('')
+  const [completing, setCompleting] = React.useState(false)
   const startedRef = React.useRef(false)
 
   const selectObservationType = (code: string) => {
@@ -156,6 +167,9 @@ export function LiveObservation() {
     const timeout = window.setTimeout(() => {
       const draft = {
         teacherUid,
+        teacherName,
+        classroomName,
+        sessionName,
         typeCode: selectedOption.code,
         storedType: storedObservationType,
         notes,
@@ -170,7 +184,7 @@ export function LiveObservation() {
         return
       }
 
-      firebase.db.collection('users').doc(auth.user.uid).set({ observationDraft: draft }, { merge: true })
+      createV2Api(firebase).saveObservationDraft(auth.user.uid, draft)
         .then(() => setDraftStatus('Auto-saved'))
         .catch(error => {
           console.error('Unable to save v2 observation draft', error)
@@ -179,30 +193,92 @@ export function LiveObservation() {
     }, 900)
 
     return () => window.clearTimeout(timeout)
-  }, [auth.user, elapsedSeconds, firebase, notes, selectedOption, storedObservationType, teacherUid])
+  }, [auth.user, classroomName, elapsedSeconds, firebase, notes, selectedOption, sessionName, storedObservationType, teacherName, teacherUid])
+
+  React.useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!selectedOption || (!event.metaKey && !event.ctrlKey)) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+      if (key === 't') {
+        event.preventDefault()
+        setNotes(current => appendTimestamp(current, elapsedSeconds))
+      }
+      if (key === 'k') {
+        event.preventDefault()
+        setNotes(current => appendTimestamp(current, elapsedSeconds, selectedOption.label))
+      }
+      if (key === 'p') {
+        event.preventDefault()
+        toast.info('Photo capture is outside this release; attach evidence in legacy CHALK for now.')
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        setAlignmentOpen(true)
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [elapsedSeconds, selectedOption, toast])
 
   const insertTag = (tag: string) => {
-    setNotes(current => `${current}${current ? '\n' : ''}[${formatElapsed(elapsedSeconds)}] ${tag}: `)
+    setNotes(current => appendTimestamp(current, elapsedSeconds, tag))
     toast.info(`${tag} tag added to notes.`)
   }
 
-  const endObservation = () => {
-    if (!auth.user) {
-      toast.info('Observation draft saved locally for preview.')
+  const toggleAlignedTag = (tag: string) => {
+    setAlignedTags(current => current.includes(tag) ? current.filter(item => item !== tag) : [...current, tag])
+  }
+
+  const completeObservation = () => {
+    if (!selectedOption || !storedObservationType || completing) {
       return
     }
 
-    createV2Api(firebase).endObservation()
-      .then(() => toast.success('Observation completed.'))
+    const payload = {
+      teacherUid,
+      teacherName,
+      classroomName,
+      sessionName,
+      typeCode: selectedOption.code,
+      storedType: storedObservationType,
+      notes,
+      elapsedSeconds,
+      updatedAt: new Date(),
+      alignedTags,
+      strength,
+      opportunity,
+      nextStep
+    }
+
+    if (!auth.user) {
+      window.localStorage.setItem('chalk-v2-observation-complete', JSON.stringify(payload))
+      window.localStorage.removeItem('chalk-v2-observation-draft')
+      toast.info('Observation completed locally for preview.')
+      history.push('/v2/plans')
+      return
+    }
+
+    setCompleting(true)
+    createV2Api(firebase).completeObservation(auth.user.uid, payload)
+      .then(() => {
+        window.localStorage.removeItem('chalk-v2-observation-draft')
+        toast.success('Observation completed and framework alignment saved.')
+        history.push('/v2/plans')
+      })
       .catch(error => {
-        console.error('Unable to end v2 observation', error)
+        console.error('Unable to complete v2 observation', error)
         toast.error('Unable to complete observation.')
+        setCompleting(false)
       })
   }
 
   if (!selectedOption || !storedObservationType) {
     return (
-      <div style={{ padding: '2rem 2.5rem', maxWidth: 1100, margin: '0 auto' }}>
+      <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1100, margin: '0 auto' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '1rem' }}>
           <div>
             <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Pick what you're observing</h1>
@@ -258,7 +334,7 @@ export function LiveObservation() {
   }
 
   return (
-    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+    <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
           <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>
@@ -274,7 +350,6 @@ export function LiveObservation() {
         <Button onClick={() => history.push('/v2/home')}>Cancel</Button>
       </div>
 
-      {/* Mode tabs + auto-save */}
       <div style={{
         background: 'var(--v2-white)',
         borderRadius: 'var(--v2-radius)',
@@ -284,59 +359,59 @@ export function LiveObservation() {
         marginBottom: '1rem',
         display: 'flex',
         justifyContent: 'space-between',
-        alignItems: 'center'
+        alignItems: 'center',
+        gap: '0.75rem',
+        flexWrap: 'wrap'
       }}>
-        <div style={{ display: 'flex', gap: '0.3rem', background: 'var(--v2-bg-soft)', padding: 4, borderRadius: 'var(--v2-radius-pill)' }}>
+        <div style={{ display: 'flex', gap: '0.3rem', background: 'var(--v2-bg-soft)', padding: 4, borderRadius: 'var(--v2-radius-pill)', flexWrap: 'wrap' }}>
           <Tab active isNew>Open mode</Tab>
           <Tab>Framework mode</Tab>
           <Tab>Quick checklist</Tab>
         </div>
         <span style={{
           display: 'inline-flex', alignItems: 'center', gap: '0.45rem',
-          background: 'var(--v2-success-soft)',
-          color: 'var(--v2-success)',
+          background: draftStatus === 'Saving...' ? 'var(--v2-brand-soft)' : 'var(--v2-success-soft)',
+          color: draftStatus === 'Saving...' ? 'var(--v2-brand-darker)' : 'var(--v2-success)',
           padding: '0.35rem 0.85rem',
           borderRadius: 'var(--v2-radius-pill)',
           fontSize: '0.78rem', fontWeight: 600
         }}>
           <span style={{
-            width: 8, height: 8, background: 'var(--v2-success)', borderRadius: '50%',
+            width: 8, height: 8, background: draftStatus === 'Saving...' ? 'var(--v2-brand)' : 'var(--v2-success)', borderRadius: '50%',
             display: 'inline-block'
           }} />
           {draftStatus}
         </span>
       </div>
 
-      {/* Main grid */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '1rem' }}>
         <Card>
-          {/* Context */}
           <div style={{
             display: 'flex', gap: '1.5rem',
             paddingBottom: '1.1rem',
             borderBottom: '1px solid var(--v2-line)',
             marginBottom: '1.25rem',
-            alignItems: 'flex-end'
+            alignItems: 'flex-end',
+            flexWrap: 'wrap'
           }}>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 160 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Teacher</div>
               <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{teacherName}</div>
             </div>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 160 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Classroom</div>
               <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{classroomName}</div>
             </div>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 160 }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Session</div>
               <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>{sessionName}</div>
             </div>
-            <div style={{ flex: 1, textAlign: 'right' }}>
+            <div style={{ flex: 1, minWidth: 150, textAlign: 'right' }}>
               <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Elapsed</div>
               <div style={{ fontFamily: 'SF Mono, monospace', fontSize: '2.1rem', fontWeight: 700, color: 'var(--v2-brand)', letterSpacing: '-0.03em', lineHeight: 1 }}>{formatElapsed(elapsedSeconds)}</div>
             </div>
           </div>
 
-          {/* Notes */}
           <div style={{
             minHeight: 280,
             border: '1px solid var(--v2-line)',
@@ -347,11 +422,11 @@ export function LiveObservation() {
             color: 'var(--v2-ink-soft)',
             background: 'var(--v2-bg-soft)'
           }}>
-            <p style={{ marginBottom: '0.8rem' }}><Ts>00:42</Ts>Started with welcome song. <Tag>SEL</Tag> Dawn sat at child-level. Two children joined late, she paused and re-welcomed them — nice.</p>
-            <p style={{ marginBottom: '0.8rem' }}><Ts>02:15</Ts>Open-ended Q: "What do you think happens when we mix red and blue?" — got 4 different responses, validated each. <Tag>Magic 9 · Listening</Tag></p>
-            <p style={{ marginBottom: '0.8rem' }}><Ts>05:48</Ts>Transition to centers — felt rushed, two kids didn't have direction. Worth flagging for action plan.</p>
-            <p style={{ marginBottom: '0.8rem' }}><Ts>09:10</Ts>Reading time. Voice modulation strong. Pacing held attention.</p>
-            <p style={{ marginBottom: '0.8rem' }}><Ts>12:30</Ts>Center cleanup → next activity. Better than transition #1, used a song to cue.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>00:42</Ts>Started with welcome song. <Tag>SEL</Tag> Teacher sat at child-level. Two children joined late and were re-welcomed calmly.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>02:15</Ts>Open-ended Q: "What do you think happens when we mix red and blue?" Responses were validated one by one. <Tag>Magic 9 · Listening</Tag></p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>05:48</Ts>Transition to centers felt rushed; two children needed repeated direction. Worth flagging for action planning.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>09:10</Ts>Reading time. Voice modulation and pacing held attention.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>12:30</Ts>Center cleanup to next activity improved after a song cue.</p>
             <p style={{ color: 'var(--v2-muted)', fontStyle: 'italic' }}>Keep typing — auto-saving as you go.</p>
             <textarea
               value={notes}
@@ -371,18 +446,17 @@ export function LiveObservation() {
             />
           </div>
 
-          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.1rem', paddingTop: '1.1rem', borderTop: '1px solid var(--v2-line)' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.1rem', paddingTop: '1.1rem', borderTop: '1px solid var(--v2-line)', flexWrap: 'wrap' }}>
             <Button onClick={() => toast.info('Photo capture is outside this release; attach evidence in legacy CHALK for now.')}>📸 Photo</Button>
             <Button onClick={() => toast.info('Audio capture is outside this release; use written notes for this sprint.')}>🎙 Audio</Button>
             <Button onClick={() => insertTag(selectedOption.label)}>🏷 Tag</Button>
             <Button onClick={startNewObservation}>Switch type</Button>
             <Button onClick={() => setPaused(current => !current)}>{paused ? '▶ Resume' : '⏸ Pause'}</Button>
             <div style={{ flex: 1 }} />
-            <Button variant="primary" onClick={endObservation}>End &amp; align to framework →</Button>
+            <Button variant="primary" onClick={() => setAlignmentOpen(true)}>End &amp; align to framework →</Button>
           </div>
         </Card>
 
-        {/* Sidebar */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <Card padding="1.15rem">
             <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>🎯 Magic 9 quick tags</h4>
@@ -393,24 +467,71 @@ export function LiveObservation() {
 
           <Card padding="1.15rem">
             <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.75rem' }}>⚡ Shortcuts</h4>
-            {[['Timestamp', '⌘ T'], ['Insert tag', '⌘ K'], ['Add photo', '⌘ P'], ['End session', '⌘ ↵']].map(([label, key]) => (
-              <div key={label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.35rem 0', fontSize: '0.82rem' }}>
-                <span>{label}</span>
-                <kbd style={{ background: 'var(--v2-bg-soft)', border: '1px solid var(--v2-line)', padding: '0.15rem 0.45rem', borderRadius: 5, fontFamily: 'SF Mono, monospace', fontSize: '0.72rem' }}>{key}</kbd>
-              </div>
-            ))}
+            {['Timestamp|⌘ T', 'Insert tag|⌘ K', 'Add photo note|⌘ P', 'End session|⌘ ↵'].map(item => {
+              const [label, key] = item.split('|')
+              return (
+                <div key={label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.35rem 0', fontSize: '0.82rem' }}>
+                  <span>{label}</span>
+                  <kbd style={{ background: 'var(--v2-bg-soft)', border: '1px solid var(--v2-line)', padding: '0.15rem 0.45rem', borderRadius: 5, fontFamily: 'SF Mono, monospace', fontSize: '0.72rem' }}>{key}</kbd>
+                </div>
+              )
+            })}
           </Card>
 
           <Card padding="1.15rem">
             <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.5rem' }}>📌 Last observation</h4>
             <div style={{ fontSize: '0.84rem', color: 'var(--v2-muted)', lineHeight: 1.55 }}>
-              <strong style={{ color: 'var(--v2-ink)', display: 'block', marginBottom: '0.2rem' }}>Apr 28 — Morning circle</strong>
+              <strong style={{ color: 'var(--v2-ink)', display: 'block', marginBottom: '0.2rem' }}>Previous session · {teacherName}</strong>
               Strengths in Listening, opportunity in Transitions.{' '}
-              <a href="#" style={{ color: 'var(--v2-brand-dark)', fontWeight: 600 }}>View →</a>
+              <button type="button" onClick={() => toast.info('Previous-observation detail remains in legacy CHALK for this sprint.')} style={{ color: 'var(--v2-brand-dark)', fontWeight: 600, padding: 0 }}>View →</button>
             </div>
           </Card>
         </div>
       </div>
+
+      {alignmentOpen && (
+        <div role="dialog" aria-modal="true" aria-label="Complete observation alignment" style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(18, 24, 31, 0.32)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '1rem',
+          zIndex: 1000
+        }}>
+          <Card style={{ width: 'min(680px, 100%)', boxShadow: 'var(--v2-shadow-lg)' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', marginBottom: '1rem' }}>
+              <div>
+                <h3 style={{ fontSize: '1.05rem', fontWeight: 700 }}>Align observation to framework</h3>
+                <p style={{ color: 'var(--v2-muted)', fontSize: '0.84rem', marginTop: '0.25rem' }}>{teacherName} · {selectedOption.label} · {formatElapsed(elapsedSeconds)}</p>
+              </div>
+              <Button size="sm" onClick={() => setAlignmentOpen(false)}>Close</Button>
+            </div>
+
+            <div style={{ display: 'grid', gap: '0.85rem' }}>
+              <div>
+                <div style={{ fontSize: '0.78rem', fontWeight: 700, color: 'var(--v2-muted)', marginBottom: '0.45rem' }}>Framework tags</div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                  {TAGS.map(tag => (
+                    <button key={tag} type="button" onClick={() => toggleAlignedTag(tag)} style={{ border: 'none', padding: 0, background: 'transparent' }}>
+                      <Chip active={alignedTags.includes(tag)}>{tag}</Chip>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <textarea value={strength} onChange={(event) => setStrength(event.currentTarget.value)} placeholder="Strength observed" style={{ minHeight: 76, border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.8rem', resize: 'vertical' }} />
+              <textarea value={opportunity} onChange={(event) => setOpportunity(event.currentTarget.value)} placeholder="Opportunity or coaching focus" style={{ minHeight: 76, border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.8rem', resize: 'vertical' }} />
+              <textarea value={nextStep} onChange={(event) => setNextStep(event.currentTarget.value)} placeholder="Next action-plan step" style={{ minHeight: 76, border: '1px solid var(--v2-line)', borderRadius: 8, padding: '0.8rem', resize: 'vertical' }} />
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
+              <Button onClick={() => setAlignmentOpen(false)}>Keep observing</Button>
+              <Button variant="primary" disabled={completing} onClick={completeObservation}>{completing ? 'Completing...' : 'Complete observation'}</Button>
+            </div>
+          </Card>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/v2/pages/LiveObservation.tsx
+++ b/src/v2/pages/LiveObservation.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react'
+import { Button } from '../components/Button'
+import { Card } from '../components/Card'
+
+const TAGS = ['Listening', 'Sequential', 'Math', 'Literacy', 'SEL', 'Engagement', 'Transitions', 'Climate', 'Instruction']
+
+function Tab(p: { active?: boolean; isNew?: boolean; children: React.ReactNode }) {
+  return (
+    <button style={{
+      padding: '0.5rem 1.1rem',
+      border: 'none',
+      background: p.active ? 'var(--v2-white)' : 'transparent',
+      fontSize: '0.85rem',
+      fontWeight: 600,
+      color: p.active ? 'var(--v2-brand-dark)' : 'var(--v2-muted)',
+      borderRadius: 'var(--v2-radius-pill)',
+      boxShadow: p.active ? 'var(--v2-shadow-sm)' : 'none',
+      cursor: 'pointer'
+    }}>
+      {p.children}
+      {p.isNew && (
+        <span style={{ background: 'var(--v2-warm)', color: '#fff', fontSize: '0.62rem', padding: '0.08rem 0.4rem', borderRadius: 4, marginLeft: '0.4rem', fontWeight: 700, verticalAlign: 1 }}>NEW</span>
+      )}
+    </button>
+  )
+}
+
+function Chip(p: { children: React.ReactNode }) {
+  return (
+    <span style={{
+      background: 'var(--v2-bg-soft)',
+      border: '1px solid var(--v2-line)',
+      padding: '0.25rem 0.65rem',
+      borderRadius: 'var(--v2-radius-pill)',
+      fontSize: '0.76rem',
+      fontWeight: 500,
+      color: 'var(--v2-ink-soft)',
+      cursor: 'pointer'
+    }}>{p.children}</span>
+  )
+}
+
+function Ts(p: { children: React.ReactNode }) {
+  return <span style={{
+    display: 'inline-block',
+    background: 'var(--v2-brand-soft)',
+    color: 'var(--v2-brand-darker)',
+    padding: '0.1rem 0.5rem',
+    borderRadius: 5,
+    fontFamily: 'SF Mono, monospace',
+    fontSize: '0.76rem',
+    fontWeight: 700,
+    marginRight: '0.5rem'
+  }}>{p.children}</span>
+}
+
+function Tag(p: { children: React.ReactNode }) {
+  return <span style={{
+    display: 'inline-block',
+    background: 'var(--v2-warm-soft)',
+    color: 'var(--v2-warm-dark)',
+    padding: '0.08rem 0.5rem',
+    borderRadius: 4,
+    fontSize: '0.76rem',
+    fontWeight: 600
+  }}>{p.children}</span>
+}
+
+export function LiveObservation() {
+  return (
+    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>
+            Live observation — <span style={{ color: 'var(--v2-brand)', fontWeight: 800 }}>Dawn Johnson</span>
+          </h1>
+          <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+            Preschool Promise · Pre-K Room · Morning circle session
+          </div>
+        </div>
+        <Button>Cancel</Button>
+      </div>
+
+      {/* Mode tabs + auto-save */}
+      <div style={{
+        background: 'var(--v2-white)',
+        borderRadius: 'var(--v2-radius)',
+        padding: '1rem 1.25rem',
+        border: '1px solid var(--v2-line-soft)',
+        boxShadow: 'var(--v2-shadow-sm)',
+        marginBottom: '1rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+      }}>
+        <div style={{ display: 'flex', gap: '0.3rem', background: 'var(--v2-bg-soft)', padding: 4, borderRadius: 'var(--v2-radius-pill)' }}>
+          <Tab active isNew>Open mode</Tab>
+          <Tab>Framework mode</Tab>
+          <Tab>Quick checklist</Tab>
+        </div>
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: '0.45rem',
+          background: 'var(--v2-success-soft)',
+          color: 'var(--v2-success)',
+          padding: '0.35rem 0.85rem',
+          borderRadius: 'var(--v2-radius-pill)',
+          fontSize: '0.78rem', fontWeight: 600
+        }}>
+          <span style={{
+            width: 8, height: 8, background: 'var(--v2-success)', borderRadius: '50%',
+            display: 'inline-block'
+          }} />
+          Auto-saved · 4s ago
+        </span>
+      </div>
+
+      {/* Main grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: '2.5fr 1fr', gap: '1rem' }}>
+        <Card>
+          {/* Context */}
+          <div style={{
+            display: 'flex', gap: '1.5rem',
+            paddingBottom: '1.1rem',
+            borderBottom: '1px solid var(--v2-line)',
+            marginBottom: '1.25rem',
+            alignItems: 'flex-end'
+          }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Teacher</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Dawn Johnson</div>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Classroom</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Preschool Promise — Pre-K</div>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Session</div>
+              <div style={{ fontWeight: 600, fontSize: '0.92rem' }}>Morning circle</div>
+            </div>
+            <div style={{ flex: 1, textAlign: 'right' }}>
+              <div style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--v2-muted)', marginBottom: '0.25rem' }}>Elapsed</div>
+              <div style={{ fontFamily: 'SF Mono, monospace', fontSize: '2.1rem', fontWeight: 700, color: 'var(--v2-brand)', letterSpacing: '-0.03em', lineHeight: 1 }}>14:32</div>
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div style={{
+            minHeight: 280,
+            border: '1px solid var(--v2-line)',
+            borderRadius: 10,
+            padding: '1.1rem',
+            fontSize: '0.92rem',
+            lineHeight: 1.75,
+            color: 'var(--v2-ink-soft)',
+            background: 'var(--v2-bg-soft)'
+          }}>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>00:42</Ts>Started with welcome song. <Tag>SEL</Tag> Dawn sat at child-level. Two children joined late, she paused and re-welcomed them — nice.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>02:15</Ts>Open-ended Q: "What do you think happens when we mix red and blue?" — got 4 different responses, validated each. <Tag>Magic 9 · Listening</Tag></p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>05:48</Ts>Transition to centers — felt rushed, two kids didn't have direction. Worth flagging for action plan.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>09:10</Ts>Reading time. Voice modulation strong. Pacing held attention.</p>
+            <p style={{ marginBottom: '0.8rem' }}><Ts>12:30</Ts>Center cleanup → next activity. Better than transition #1, used a song to cue.</p>
+            <p style={{ color: 'var(--v2-muted)', fontStyle: 'italic' }}>Keep typing — auto-saving as you go.</p>
+          </div>
+
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.1rem', paddingTop: '1.1rem', borderTop: '1px solid var(--v2-line)' }}>
+            <Button>📸 Photo</Button>
+            <Button>🎙 Audio</Button>
+            <Button>🏷 Tag</Button>
+            <Button>⏸ Pause</Button>
+            <div style={{ flex: 1 }} />
+            <Button variant="primary">End &amp; align to framework →</Button>
+          </div>
+        </Card>
+
+        {/* Sidebar */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <Card padding="1.15rem">
+            <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>🎯 Magic 9 quick tags</h4>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
+              {TAGS.map(t => <Chip key={t}>{t}</Chip>)}
+            </div>
+          </Card>
+
+          <Card padding="1.15rem">
+            <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.75rem' }}>⚡ Shortcuts</h4>
+            {[['Timestamp', '⌘ T'], ['Insert tag', '⌘ K'], ['Add photo', '⌘ P'], ['End session', '⌘ ↵']].map(([label, key]) => (
+              <div key={label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0.35rem 0', fontSize: '0.82rem' }}>
+                <span>{label}</span>
+                <kbd style={{ background: 'var(--v2-bg-soft)', border: '1px solid var(--v2-line)', padding: '0.15rem 0.45rem', borderRadius: 5, fontFamily: 'SF Mono, monospace', fontSize: '0.72rem' }}>{key}</kbd>
+              </div>
+            ))}
+          </Card>
+
+          <Card padding="1.15rem">
+            <h4 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '0.5rem' }}>📌 Last observation</h4>
+            <div style={{ fontSize: '0.84rem', color: 'var(--v2-muted)', lineHeight: 1.55 }}>
+              <strong style={{ color: 'var(--v2-ink)', display: 'block', marginBottom: '0.2rem' }}>Apr 28 — Morning circle</strong>
+              Strengths in Listening, opportunity in Transitions.{' '}
+              <a href="#" style={{ color: 'var(--v2-brand-dark)', fontWeight: 600 }}>View →</a>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/v2/pages/PlaceholderPage.tsx
+++ b/src/v2/pages/PlaceholderPage.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+
+export function PlaceholderPage(props: { title: string; subtitle?: string }) {
+  return (
+    <div style={{ padding: '4rem 2.5rem', textAlign: 'center', maxWidth: 720, margin: '0 auto' }}>
+      <div style={{
+        display: 'inline-block',
+        background: 'var(--v2-warm-soft)',
+        color: 'var(--v2-warm-dark)',
+        padding: '0.4rem 1rem',
+        borderRadius: 'var(--v2-radius-pill)',
+        fontSize: '0.72rem',
+        fontWeight: 700,
+        letterSpacing: '0.18em',
+        textTransform: 'uppercase',
+        marginBottom: '1.5rem'
+      }}>Coming Day 2–10</div>
+      <h1 style={{ fontSize: '2.4rem', fontWeight: 700, letterSpacing: '-0.02em', marginBottom: '1rem' }}>
+        {props.title}
+      </h1>
+      <p style={{ fontSize: '1.1rem', color: 'var(--v2-muted)', fontWeight: 300, lineHeight: 1.55 }}>
+        {props.subtitle ?? 'This view will be built once Phase 1 (Coach Home) is signed off. The interactive mockup shows the design direction.'}
+      </p>
+    </div>
+  )
+}

--- a/src/v2/pages/PlanDetail.tsx
+++ b/src/v2/pages/PlanDetail.tsx
@@ -1,7 +1,45 @@
 import * as React from 'react'
+import { useParams } from 'react-router-dom'
 import { Avatar } from '../components/Avatar'
 import { Button } from '../components/Button'
 import { Card, CardHeader } from '../components/Card'
+import { EmptyState } from '../components/EmptyState'
+import { Skeleton } from '../components/Skeleton'
+import { useToast } from '../hooks/useToast'
+import { useV2Auth } from '../hooks/useV2Auth'
+import { useV2Firebase } from '../lib/firebase'
+import { createV2Api } from '../lib/api'
+import { PlanComment, PlanDetail as V2PlanDetail, PlanStep } from '../lib/types'
+
+const DEMO_PLAN: V2PlanDetail = {
+  id: 'demo-plan',
+  title: 'Reducing transition time',
+  teacherId: 'demo-chrystaline',
+  teacherName: 'Morgan Lee',
+  goal: 'Reduce the average transition time between activities from 5 minutes to under 2 minutes, while maintaining smooth flow and minimal disruption.',
+  benefit: 'Tisha will observe two transitions per week and log timing. Target: average under 2:00 by May 28.',
+  dueDate: new Date('2026-05-28T12:00:00'),
+  progress: 65,
+  steps: [
+    { step: 'Introduce a transition song as a cue. Use the same song daily for one week.', person: 'Morgan', timeline: new Date('2026-05-22T12:00:00') },
+    { step: 'Set up the next activity materials before ending the current one.', person: 'Morgan', timeline: new Date('2026-05-25T12:00:00') },
+    { step: 'Self-time each transition using the in-app timer.', person: 'Morgan', timeline: new Date('2026-05-27T12:00:00') }
+  ],
+  comments: [
+    { id: 'c1', name: 'Demo Coach', time: 'May 6 · 2:14 PM', text: 'Here is the transition plan we discussed. The first step is to use one consistent cue before cleanup.' },
+    { id: 'c2', name: 'Morgan Lee', time: 'May 7 · 9:32 AM', text: 'Tried the cleanup cue this morning. The transition was shorter and the children knew what to do next.' },
+    { id: 'c3', name: 'Demo Coach', time: 'May 7 · 11:05 AM', text: 'Good progress. We will keep tracking the timing during the next observation.' }
+  ]
+}
+
+function dateInputValue(date: Date | null): string {
+  if (!date) return ''
+  return date.toISOString().slice(0, 10)
+}
+
+function formatDueDate(date: Date | null): string {
+  return date ? date.toLocaleDateString() : 'No due date'
+}
 
 function Field(p: { label: string; children: React.ReactNode }) {
   return (
@@ -26,7 +64,7 @@ function Field(p: { label: string; children: React.ReactNode }) {
   )
 }
 
-function Comment(p: { name: string; time: string; text: string }) {
+function Comment(p: PlanComment) {
   return (
     <div style={{ display: 'flex', gap: '0.65rem', padding: '0.85rem 0', borderBottom: '1px solid var(--v2-line-soft)' }}>
       <Avatar name={p.name} size={30} />
@@ -41,93 +79,285 @@ function Comment(p: { name: string; time: string; text: string }) {
   )
 }
 
+function EditableTextArea(props: { value: string; onChange(value: string): void; minHeight?: number }) {
+  return (
+    <textarea
+      value={props.value}
+      onChange={(event) => props.onChange(event.currentTarget.value)}
+      style={{
+        width: '100%',
+        minHeight: props.minHeight || 110,
+        border: '1px solid var(--v2-line)',
+        borderRadius: 8,
+        padding: '0.8rem',
+        background: 'var(--v2-white)',
+        color: 'var(--v2-ink)',
+        resize: 'vertical',
+        lineHeight: 1.55
+      }}
+    />
+  )
+}
+
 export function PlanDetail() {
+  const { planId } = useParams<{ planId?: string }>()
+  const firebase = useV2Firebase()
+  const auth = useV2Auth()
+  const toast = useToast()
+  const [plan, setPlan] = React.useState<V2PlanDetail>(DEMO_PLAN)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+  const [savedLabel, setSavedLabel] = React.useState('Saved locally')
+  const [commentText, setCommentText] = React.useState('')
+  const realPlanId = planId && planId !== 'demo-plan' ? planId : ''
+
+  React.useEffect(() => {
+    if (!realPlanId || !auth.user) {
+      const cached = window.localStorage.getItem('chalk-v2-plan-draft')
+      if (cached) {
+        try {
+          const parsed = JSON.parse(cached)
+          setPlan({ ...DEMO_PLAN, ...parsed, dueDate: parsed.dueDate ? new Date(parsed.dueDate) : DEMO_PLAN.dueDate })
+        } catch (error) {
+          console.error('Unable to parse local v2 plan draft', error)
+        }
+      }
+      return
+    }
+
+    let active = true
+    setLoading(true)
+    setError(null)
+    createV2Api(firebase).getActionPlanFull(realPlanId).then(nextPlan => {
+      if (!active) return
+      if (nextPlan) {
+        setPlan(nextPlan)
+        setSavedLabel('Loaded from CHALK')
+      }
+      setLoading(false)
+    }).catch(fetchError => {
+      if (!active) return
+      setError(fetchError as Error)
+      setLoading(false)
+    })
+
+    return () => { active = false }
+  }, [auth.user, firebase, realPlanId])
+
+  React.useEffect(() => {
+    if (loading) {
+      return
+    }
+
+    setSavedLabel(auth.user && realPlanId ? 'Saving...' : 'Saving locally...')
+    const timeout = window.setTimeout(() => {
+      if (!auth.user || !realPlanId) {
+        window.localStorage.setItem('chalk-v2-plan-draft', JSON.stringify({
+          ...plan,
+          dueDate: plan.dueDate ? plan.dueDate.toISOString() : null
+        }))
+        setSavedLabel('Saved locally')
+        return
+      }
+
+      createV2Api(firebase).saveActionPlanDraft(realPlanId, {
+        title: plan.title,
+        goal: plan.goal,
+        benefit: plan.benefit,
+        dueDate: plan.dueDate
+      }).then(() => {
+        setSavedLabel('Auto-saved')
+      }).catch(saveError => {
+        console.error('Unable to autosave v2 action plan', saveError)
+        setSavedLabel('Save failed')
+      })
+    }, 900)
+
+    return () => window.clearTimeout(timeout)
+  }, [auth.user, firebase, loading, plan.benefit, plan.dueDate, plan.goal, plan.title, realPlanId])
+
+  const updatePlan = (patch: Partial<V2PlanDetail>) => {
+    setPlan(current => ({ ...current, ...patch }))
+  }
+
+  const updateStep = (index: number, patch: Partial<PlanStep>) => {
+    setPlan(current => ({
+      ...current,
+      steps: current.steps.map((step, stepIndex) => stepIndex === index ? { ...step, ...patch } : step)
+    }))
+  }
+
+  const addStep = () => {
+    setPlan(current => ({
+      ...current,
+      steps: [...current.steps, { step: '', person: '', timeline: null }]
+    }))
+  }
+
+  const addComment = () => {
+    const text = commentText.trim()
+    if (!text) {
+      return
+    }
+
+    const authorName = auth.user ? `${auth.user.firstName} ${auth.user.lastName}`.trim() || 'CHALK user' : 'Preview coach'
+    setCommentText('')
+
+    if (!auth.user || !realPlanId) {
+      setPlan(current => ({
+        ...current,
+        comments: [...current.comments, { id: `local-${Date.now()}`, name: authorName, time: new Date().toLocaleString(), text }]
+      }))
+      toast.info('Comment saved locally for preview.')
+      return
+    }
+
+    createV2Api(firebase).addActionPlanComment(realPlanId, { authorName, authorId: auth.user.uid, text })
+      .then(comment => {
+        setPlan(current => ({ ...current, comments: [...current.comments, comment] }))
+        toast.success('Comment added.')
+      })
+      .catch(commentError => {
+        console.error('Unable to add v2 plan comment', commentError)
+        toast.error('Unable to add comment.')
+      })
+  }
+
+  const sendToTeacher = () => {
+    if (!auth.user || !realPlanId) {
+      toast.info('Send-to-teacher is ready for live plans after staging signoff.')
+      return
+    }
+
+    createV2Api(firebase).markActionPlanSentToTeacher(realPlanId, auth.user.uid)
+      .then(() => toast.success('Plan marked as sent to teacher.'))
+      .catch(sendError => {
+        console.error('Unable to mark v2 plan as sent', sendError)
+        toast.error('Unable to send plan.')
+      })
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+        <Skeleton width="40%" height={32} style={{ marginBottom: '1rem' }} />
+        <Skeleton height={240} />
+      </div>
+    )
+  }
+
   return (
     <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
-      {/* Header */}
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
         marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
       }}>
         <div>
           <div style={{ fontSize: '0.78rem', color: 'var(--v2-muted)', marginBottom: '0.3rem' }}>
-            Action Plans / Chrystaline Glenn
+            Action Plans / {plan.teacherName}
           </div>
-          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Reducing transition time</h1>
+          <input
+            value={plan.title}
+            onChange={(event) => updatePlan({ title: event.currentTarget.value })}
+            style={{
+              width: '100%',
+              maxWidth: 620,
+              border: 'none',
+              outline: 'none',
+              background: 'transparent',
+              color: 'var(--v2-ink)',
+              fontSize: '1.7rem',
+              fontWeight: 700,
+              letterSpacing: '-0.02em'
+            }}
+          />
           <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
-            For Chrystaline Glenn · created May 6 · due May 28
+            For {plan.teacherName} · due {formatDueDate(plan.dueDate)}
           </div>
+          {error && (
+            <div style={{ color: 'var(--v2-warm-dark)', fontSize: '0.82rem', marginTop: '0.4rem', fontWeight: 600 }}>
+              Live plan unavailable; showing editable local draft.
+            </div>
+          )}
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <span style={{
             display: 'inline-flex', alignItems: 'center', gap: '0.4rem',
-            background: 'var(--v2-success-soft)',
-            color: 'var(--v2-success)',
+            background: savedLabel === 'Save failed' ? 'var(--v2-warm-soft)' : 'var(--v2-success-soft)',
+            color: savedLabel === 'Save failed' ? 'var(--v2-warm-dark)' : 'var(--v2-success)',
             padding: '0.35rem 0.85rem',
             borderRadius: 'var(--v2-radius-pill)',
             fontSize: '0.78rem', fontWeight: 600
-          }}>✓ Saved 3s ago</span>
-          <Button>⋯ More</Button>
-          <Button variant="primary">📨 Send to teacher</Button>
+          }}>{savedLabel}</span>
+          <Button onClick={() => toast.info('Additional plan actions remain in legacy CHALK for this sprint.')}>⋯ More</Button>
+          <Button variant="primary" onClick={sendToTeacher}>📨 Send to teacher</Button>
         </div>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '1rem' }}>
-        {/* Left: plan content */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '1rem' }}>
         <div>
           <Card style={{ marginBottom: '0.85rem' }} padding="1.35rem">
             <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>🎯 Goal</h3>
-            <p style={{ fontSize: '0.9rem', color: 'var(--v2-ink-soft)' }}>
-              Reduce the average transition time between activities from 5 minutes to under 2 minutes, while maintaining smooth flow and minimal disruption.
-            </p>
+            <EditableTextArea value={plan.goal} onChange={(goal) => updatePlan({ goal })} />
           </Card>
 
           <Card style={{ marginBottom: '0.85rem' }} padding="1.35rem">
-            <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>📋 Action steps</h3>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+              <h3 style={{ fontSize: '0.95rem', fontWeight: 700 }}>📋 Action steps</h3>
+              <Button size="sm" onClick={addStep}>+ Step</Button>
+            </div>
             <div style={{ display: 'grid', gap: '0.65rem' }}>
-              <Field label="Step 1 · By May 22">
-                Introduce a transition song as a cue. Use the same song daily for one week.
-              </Field>
-              <Field label="Step 2 · By May 25">
-                Set up the next activity materials before ending the current one (parallel prep).
-              </Field>
-              <Field label="Step 3 · By May 27">
-                Self-time each transition using the in-app timer. Log duration in observation notes.
-              </Field>
+              {plan.steps.map((step, index) => (
+                <Field key={index} label={`Step ${index + 1}`}>
+                  <input
+                    value={step.step || ''}
+                    onChange={(event) => updateStep(index, { step: event.currentTarget.value })}
+                    placeholder="Action step"
+                    style={{ width: '100%', border: 'none', background: 'transparent', outline: 'none', color: 'var(--v2-ink)', marginBottom: '0.45rem' }}
+                  />
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <input
+                      value={step.person || ''}
+                      onChange={(event) => updateStep(index, { person: event.currentTarget.value })}
+                      placeholder="Owner"
+                      style={{ flex: 1, border: '1px solid var(--v2-line)', borderRadius: 6, padding: '0.4rem 0.55rem', background: 'var(--v2-white)' }}
+                    />
+                    <input
+                      type="date"
+                      value={dateInputValue(step.timeline)}
+                      onChange={(event) => updateStep(index, { timeline: event.currentTarget.value ? new Date(`${event.currentTarget.value}T12:00:00`) : null })}
+                      style={{ border: '1px solid var(--v2-line)', borderRadius: 6, padding: '0.4rem 0.55rem', background: 'var(--v2-white)' }}
+                    />
+                  </div>
+                </Field>
+              ))}
             </div>
           </Card>
 
           <Card padding="1.35rem">
-            <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>📊 Measurement</h3>
-            <p style={{ fontSize: '0.9rem', color: 'var(--v2-ink-soft)' }}>
-              Tisha will observe two transitions per week and log timing. Target: average under 2:00 by May 28.
-            </p>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+              <h3 style={{ fontSize: '0.95rem', fontWeight: 700 }}>📊 Measurement</h3>
+              <input
+                type="date"
+                value={dateInputValue(plan.dueDate)}
+                onChange={(event) => updatePlan({ dueDate: event.currentTarget.value ? new Date(`${event.currentTarget.value}T12:00:00`) : null })}
+                style={{ border: '1px solid var(--v2-line)', borderRadius: 6, padding: '0.4rem 0.55rem', background: 'var(--v2-white)' }}
+              />
+            </div>
+            <EditableTextArea value={plan.benefit} onChange={(benefit) => updatePlan({ benefit })} minHeight={90} />
           </Card>
         </div>
 
-        {/* Right: conversation + progress */}
         <div>
           <Card padding="1.35rem">
             <div style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.65rem' }}>
               💬 Conversation
-              <span style={{ fontWeight: 400, color: 'var(--v2-muted)', fontSize: '0.75rem', marginLeft: '0.5rem' }}>3 messages · in CHALK</span>
+              <span style={{ fontWeight: 400, color: 'var(--v2-muted)', fontSize: '0.75rem', marginLeft: '0.5rem' }}>{plan.comments.length} messages · in CHALK</span>
             </div>
 
-            <Comment
-              name="Tisha Owen"
-              time="May 6 · 2:14 PM"
-              text="Chrystaline, here's the plan we discussed. The song idea came up because I noticed kids respond well to your singing during circle time."
-            />
-            <Comment
-              name="Chrystaline Glenn"
-              time="May 7 · 9:32 AM"
-              text='Got it — tried "Tidy Up" song this morning, kids loved it. Transition went from ~5 min to ~3 min. 🎉'
-            />
-            <Comment
-              name="Tisha Owen"
-              time="May 7 · 11:05 AM"
-              text="Amazing progress! Let's keep tracking — I'll observe tomorrow morning."
-            />
+            {plan.comments.length > 0 ? plan.comments.map(comment => <Comment key={comment.id} {...comment} />) : (
+              <EmptyState title="No comments yet" description="Plan comments between coach and teacher will appear here." />
+            )}
 
             <div style={{
               marginTop: '0.85rem',
@@ -138,20 +368,23 @@ export function PlanDetail() {
             }}>
               <input
                 type="text"
-                placeholder="Write a message…"
+                value={commentText}
+                onChange={(event) => setCommentText(event.currentTarget.value)}
+                onKeyDown={(event) => { if (event.key === 'Enter') addComment() }}
+                placeholder="Write a message..."
                 style={{ border: 'none', outline: 'none', flex: 1, background: 'transparent', fontSize: '0.85rem', color: 'var(--v2-ink)' }}
               />
-              <Button variant="primary" size="sm">Send</Button>
+              <Button variant="primary" size="sm" onClick={addComment}>Send</Button>
             </div>
           </Card>
 
           <Card style={{ marginTop: '1rem' }} padding="1.35rem">
             <CardHeader title="📈 Progress" />
             <div style={{ height: 6, background: 'var(--v2-bg-soft)', borderRadius: 999, overflow: 'hidden', marginBottom: '0.5rem' }}>
-              <div style={{ height: '100%', width: '65%', background: 'var(--v2-brand)', borderRadius: 999 }} />
+              <div style={{ height: '100%', width: `${plan.progress}%`, background: 'var(--v2-brand)', borderRadius: 999 }} />
             </div>
             <div style={{ fontSize: '0.78rem', color: 'var(--v2-muted)', display: 'flex', justifyContent: 'space-between' }}>
-              <span>2 of 3 steps complete</span><span>8 days remaining</span>
+              <span>{plan.progress}% complete</span><span>{plan.steps.length} steps</span>
             </div>
           </Card>
         </div>

--- a/src/v2/pages/PlanDetail.tsx
+++ b/src/v2/pages/PlanDetail.tsx
@@ -14,10 +14,10 @@ import { PlanComment, PlanDetail as V2PlanDetail, PlanStep } from '../lib/types'
 const DEMO_PLAN: V2PlanDetail = {
   id: 'demo-plan',
   title: 'Reducing transition time',
-  teacherId: 'demo-chrystaline',
+  teacherId: 'demo-teacher-2',
   teacherName: 'Morgan Lee',
   goal: 'Reduce the average transition time between activities from 5 minutes to under 2 minutes, while maintaining smooth flow and minimal disruption.',
-  benefit: 'Tisha will observe two transitions per week and log timing. Target: average under 2:00 by May 28.',
+  benefit: 'Coach will observe two transitions per week and log timing. Target: average under 2:00 by May 28.',
   dueDate: new Date('2026-05-28T12:00:00'),
   progress: 65,
   steps: [
@@ -109,7 +109,14 @@ export function PlanDetail() {
   const [error, setError] = React.useState<Error | null>(null)
   const [savedLabel, setSavedLabel] = React.useState('Saved locally')
   const [commentText, setCommentText] = React.useState('')
+  const [showSendConfirm, setShowSendConfirm] = React.useState(false)
+  const [sending, setSending] = React.useState(false)
   const realPlanId = planId && planId !== 'demo-plan' ? planId : ''
+  const serializedSteps = JSON.stringify(plan.steps.map(step => ({
+    step: step.step,
+    person: step.person,
+    timeline: step.timeline ? step.timeline.toISOString() : null
+  })))
 
   React.useEffect(() => {
     if (!realPlanId || !auth.user) {
@@ -164,7 +171,8 @@ export function PlanDetail() {
         title: plan.title,
         goal: plan.goal,
         benefit: plan.benefit,
-        dueDate: plan.dueDate
+        dueDate: plan.dueDate,
+        steps: plan.steps
       }).then(() => {
         setSavedLabel('Auto-saved')
       }).catch(saveError => {
@@ -174,7 +182,7 @@ export function PlanDetail() {
     }, 900)
 
     return () => window.clearTimeout(timeout)
-  }, [auth.user, firebase, loading, plan.benefit, plan.dueDate, plan.goal, plan.title, realPlanId])
+  }, [auth.user, firebase, loading, plan.benefit, plan.dueDate, plan.goal, plan.title, realPlanId, serializedSteps])
 
   const updatePlan = (patch: Partial<V2PlanDetail>) => {
     setPlan(current => ({ ...current, ...patch }))
@@ -229,17 +237,31 @@ export function PlanDetail() {
       return
     }
 
+    setShowSendConfirm(true)
+  }
+
+  const confirmSendToTeacher = () => {
+    if (!auth.user || !realPlanId || sending) {
+      return
+    }
+
+    setSending(true)
     createV2Api(firebase).markActionPlanSentToTeacher(realPlanId, auth.user.uid)
-      .then(() => toast.success('Plan marked as sent to teacher.'))
+      .then(() => {
+        setShowSendConfirm(false)
+        setSending(false)
+        toast.success('Plan marked as sent to teacher.')
+      })
       .catch(sendError => {
         console.error('Unable to mark v2 plan as sent', sendError)
+        setSending(false)
         toast.error('Unable to send plan.')
       })
   }
 
   if (loading) {
     return (
-      <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
         <Skeleton width="40%" height={32} style={{ marginBottom: '1rem' }} />
         <Skeleton height={240} />
       </div>
@@ -247,7 +269,7 @@ export function PlanDetail() {
   }
 
   return (
-    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+    <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
         marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
@@ -280,7 +302,7 @@ export function PlanDetail() {
             </div>
           )}
         </div>
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
           <span style={{
             display: 'inline-flex', alignItems: 'center', gap: '0.4rem',
             background: savedLabel === 'Save failed' ? 'var(--v2-warm-soft)' : 'var(--v2-success-soft)',
@@ -315,12 +337,12 @@ export function PlanDetail() {
                     placeholder="Action step"
                     style={{ width: '100%', border: 'none', background: 'transparent', outline: 'none', color: 'var(--v2-ink)', marginBottom: '0.45rem' }}
                   />
-                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                     <input
                       value={step.person || ''}
                       onChange={(event) => updateStep(index, { person: event.currentTarget.value })}
                       placeholder="Owner"
-                      style={{ flex: 1, border: '1px solid var(--v2-line)', borderRadius: 6, padding: '0.4rem 0.55rem', background: 'var(--v2-white)' }}
+                      style={{ flex: 1, minWidth: 130, border: '1px solid var(--v2-line)', borderRadius: 6, padding: '0.4rem 0.55rem', background: 'var(--v2-white)' }}
                     />
                     <input
                       type="date"
@@ -335,7 +357,7 @@ export function PlanDetail() {
           </Card>
 
           <Card padding="1.35rem">
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem', gap: '0.75rem', flexWrap: 'wrap' }}>
               <h3 style={{ fontSize: '0.95rem', fontWeight: 700 }}>📊 Measurement</h3>
               <input
                 type="date"
@@ -389,6 +411,30 @@ export function PlanDetail() {
           </Card>
         </div>
       </div>
+
+      {showSendConfirm && (
+        <div role="dialog" aria-modal="true" aria-label="Send plan to teacher" style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(18, 24, 31, 0.28)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '1rem',
+          zIndex: 1000
+        }}>
+          <Card style={{ width: 'min(520px, 100%)', boxShadow: 'var(--v2-shadow-lg)' }}>
+            <h3 style={{ fontSize: '1.05rem', marginBottom: '0.45rem' }}>Send this plan to {plan.teacherName}?</h3>
+            <p style={{ color: 'var(--v2-muted)', fontSize: '0.86rem', lineHeight: 1.55 }}>
+              This will mark the action plan as sent in Firestore. Review the goal, steps, measurement date, and conversation before confirming.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
+              <Button onClick={() => setShowSendConfirm(false)}>Cancel</Button>
+              <Button variant="primary" disabled={sending} onClick={confirmSendToTeacher}>{sending ? 'Sending...' : 'Confirm send'}</Button>
+            </div>
+          </Card>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/v2/pages/PlanDetail.tsx
+++ b/src/v2/pages/PlanDetail.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import { Avatar } from '../components/Avatar'
+import { Button } from '../components/Button'
+import { Card, CardHeader } from '../components/Card'
+
+function Field(p: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{
+      border: '1px solid var(--v2-line)',
+      borderRadius: 8,
+      padding: '0.7rem 0.9rem',
+      background: 'var(--v2-bg-soft)',
+      fontSize: '0.88rem'
+    }}>
+      <strong style={{
+        display: 'block',
+        fontSize: '0.68rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+        color: 'var(--v2-brand-dark)',
+        fontWeight: 700,
+        marginBottom: '0.25rem'
+      }}>{p.label}</strong>
+      {p.children}
+    </div>
+  )
+}
+
+function Comment(p: { name: string; time: string; text: string }) {
+  return (
+    <div style={{ display: 'flex', gap: '0.65rem', padding: '0.85rem 0', borderBottom: '1px solid var(--v2-line-soft)' }}>
+      <Avatar name={p.name} size={30} />
+      <div style={{ flex: 1 }}>
+        <div style={{ display: 'flex', gap: '0.45rem', alignItems: 'baseline', fontSize: '0.78rem', marginBottom: '0.2rem' }}>
+          <strong style={{ fontSize: '0.82rem' }}>{p.name}</strong>
+          <span style={{ color: 'var(--v2-muted)' }}>{p.time}</span>
+        </div>
+        <div style={{ fontSize: '0.86rem', color: 'var(--v2-ink-soft)' }}>{p.text}</div>
+      </div>
+    </div>
+  )
+}
+
+export function PlanDetail() {
+  return (
+    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+        marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem'
+      }}>
+        <div>
+          <div style={{ fontSize: '0.78rem', color: 'var(--v2-muted)', marginBottom: '0.3rem' }}>
+            Action Plans / Chrystaline Glenn
+          </div>
+          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Reducing transition time</h1>
+          <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+            For Chrystaline Glenn · created May 6 · due May 28
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', gap: '0.4rem',
+            background: 'var(--v2-success-soft)',
+            color: 'var(--v2-success)',
+            padding: '0.35rem 0.85rem',
+            borderRadius: 'var(--v2-radius-pill)',
+            fontSize: '0.78rem', fontWeight: 600
+          }}>✓ Saved 3s ago</span>
+          <Button>⋯ More</Button>
+          <Button variant="primary">📨 Send to teacher</Button>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '1rem' }}>
+        {/* Left: plan content */}
+        <div>
+          <Card style={{ marginBottom: '0.85rem' }} padding="1.35rem">
+            <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>🎯 Goal</h3>
+            <p style={{ fontSize: '0.9rem', color: 'var(--v2-ink-soft)' }}>
+              Reduce the average transition time between activities from 5 minutes to under 2 minutes, while maintaining smooth flow and minimal disruption.
+            </p>
+          </Card>
+
+          <Card style={{ marginBottom: '0.85rem' }} padding="1.35rem">
+            <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>📋 Action steps</h3>
+            <div style={{ display: 'grid', gap: '0.65rem' }}>
+              <Field label="Step 1 · By May 22">
+                Introduce a transition song as a cue. Use the same song daily for one week.
+              </Field>
+              <Field label="Step 2 · By May 25">
+                Set up the next activity materials before ending the current one (parallel prep).
+              </Field>
+              <Field label="Step 3 · By May 27">
+                Self-time each transition using the in-app timer. Log duration in observation notes.
+              </Field>
+            </div>
+          </Card>
+
+          <Card padding="1.35rem">
+            <h3 style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.75rem' }}>📊 Measurement</h3>
+            <p style={{ fontSize: '0.9rem', color: 'var(--v2-ink-soft)' }}>
+              Tisha will observe two transitions per week and log timing. Target: average under 2:00 by May 28.
+            </p>
+          </Card>
+        </div>
+
+        {/* Right: conversation + progress */}
+        <div>
+          <Card padding="1.35rem">
+            <div style={{ fontSize: '0.95rem', fontWeight: 700, marginBottom: '0.65rem' }}>
+              💬 Conversation
+              <span style={{ fontWeight: 400, color: 'var(--v2-muted)', fontSize: '0.75rem', marginLeft: '0.5rem' }}>3 messages · in CHALK</span>
+            </div>
+
+            <Comment
+              name="Tisha Owen"
+              time="May 6 · 2:14 PM"
+              text="Chrystaline, here's the plan we discussed. The song idea came up because I noticed kids respond well to your singing during circle time."
+            />
+            <Comment
+              name="Chrystaline Glenn"
+              time="May 7 · 9:32 AM"
+              text='Got it — tried "Tidy Up" song this morning, kids loved it. Transition went from ~5 min to ~3 min. 🎉'
+            />
+            <Comment
+              name="Tisha Owen"
+              time="May 7 · 11:05 AM"
+              text="Amazing progress! Let's keep tracking — I'll observe tomorrow morning."
+            />
+
+            <div style={{
+              marginTop: '0.85rem',
+              border: '1px solid var(--v2-line)',
+              borderRadius: 'var(--v2-radius-pill)',
+              padding: '0.4rem 0.55rem 0.4rem 1.1rem',
+              display: 'flex', alignItems: 'center', gap: '0.5rem'
+            }}>
+              <input
+                type="text"
+                placeholder="Write a message…"
+                style={{ border: 'none', outline: 'none', flex: 1, background: 'transparent', fontSize: '0.85rem', color: 'var(--v2-ink)' }}
+              />
+              <Button variant="primary" size="sm">Send</Button>
+            </div>
+          </Card>
+
+          <Card style={{ marginTop: '1rem' }} padding="1.35rem">
+            <CardHeader title="📈 Progress" />
+            <div style={{ height: 6, background: 'var(--v2-bg-soft)', borderRadius: 999, overflow: 'hidden', marginBottom: '0.5rem' }}>
+              <div style={{ height: '100%', width: '65%', background: 'var(--v2-brand)', borderRadius: 999 }} />
+            </div>
+            <div style={{ fontSize: '0.78rem', color: 'var(--v2-muted)', display: 'flex', justifyContent: 'space-between' }}>
+              <span>2 of 3 steps complete</span><span>8 days remaining</span>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/v2/pages/Training.tsx
+++ b/src/v2/pages/Training.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import { Button } from '../components/Button'
+
+type Reason = 'alert' | 'win' | 'skip'
+
+type TrainingCard = {
+  title: string
+  icon: string
+  tone: 'warm' | 'brand' | 'success' | 'gold' | 'purple'
+  reason: Reason
+  reasonText: string
+  ctaText: string
+  ctaVariant?: 'default' | 'primary'
+}
+
+const CARDS: TrainingCard[] = [
+  { title: 'Smooth Transitions', icon: '⏱', tone: 'warm', reason: 'alert', reasonText: '⚠ 3 of your teachers flagged in this area', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
+  { title: 'Open-Ended Questions', icon: '🗣', tone: 'brand', reason: 'alert', reasonText: '⚠ Recurring theme in last 5 observations', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
+  { title: 'Classroom Climate', icon: '💚', tone: 'success', reason: 'win', reasonText: '✓ You scored in the top 10% — refresh available', ctaText: 'Refresh (8 min)' },
+  { title: 'Conscious Discipline Foundations', icon: '📚', tone: 'purple', reason: 'skip', reasonText: 'Completed in 2024 — skip unless needed', ctaText: 'Review notes' },
+  { title: 'Using Magic 9 effectively', icon: '📊', tone: 'gold', reason: 'skip', reasonText: 'Optional · recommended for new coaches', ctaText: 'Not now' },
+  { title: 'Writing better action plans', icon: '🎯', tone: 'warm', reason: 'alert', reasonText: '⚠ Your last 2 plans had no measurable goals', ctaText: 'Start (12 min)', ctaVariant: 'primary' }
+]
+
+const toneBg: Record<TrainingCard['tone'], string> = {
+  warm: 'linear-gradient(135deg, #f0523d, #d63a26)',
+  brand: 'linear-gradient(135deg, #00b2ff, #006fa5)',
+  success: 'linear-gradient(135deg, #2ECC71, #169c54)',
+  gold: 'linear-gradient(135deg, #f0a623, #c47e15)',
+  purple: 'linear-gradient(135deg, #6f39c4, #f0523d)'
+}
+
+const reasonStyle: Record<Reason, { bg: string; fg: string }> = {
+  alert:   { bg: 'var(--v2-warm-soft)', fg: 'var(--v2-warm-dark)' },
+  win:     { bg: 'var(--v2-success-soft)', fg: '#15803D' },
+  skip:    { bg: 'var(--v2-bg-soft)', fg: 'var(--v2-muted)' }
+}
+
+export function Training() {
+  return (
+    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Training tailored to your coaching</h1>
+          <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
+            Based on patterns in your recent observations and action plans — recommended, not required.
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Button>All training</Button>
+          <Button>Completed</Button>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
+        {CARDS.map((c, i) => (
+          <div key={i} style={{
+            background: 'var(--v2-white)',
+            borderRadius: 'var(--v2-radius)',
+            border: '1px solid var(--v2-line-soft)',
+            overflow: 'hidden',
+            boxShadow: 'var(--v2-shadow-sm)'
+          }}>
+            <div style={{
+              height: 120,
+              background: toneBg[c.tone],
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#fff',
+              fontSize: '2rem'
+            }}>
+              {c.icon}
+            </div>
+            <div style={{ padding: '1.1rem' }}>
+              <h4 style={{ fontSize: '0.98rem', fontWeight: 600, marginBottom: '0.35rem' }}>{c.title}</h4>
+              <div style={{
+                fontSize: '0.76rem',
+                padding: '0.4rem 0.6rem',
+                borderRadius: 6,
+                margin: '0.5rem 0 0.8rem',
+                fontWeight: 600,
+                background: reasonStyle[c.reason].bg,
+                color: reasonStyle[c.reason].fg
+              }}>{c.reasonText}</div>
+              <div style={{ display: 'flex', gap: '0.4rem' }}>
+                <Button
+                  variant={c.ctaVariant === 'primary' ? 'primary' : 'default'}
+                  size="sm"
+                  style={{ flex: 1, justifyContent: 'center' }}
+                >
+                  {c.ctaText}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/v2/pages/Training.tsx
+++ b/src/v2/pages/Training.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react'
 import { Button } from '../components/Button'
+import { EmptyState } from '../components/EmptyState'
+import { Skeleton } from '../components/Skeleton'
+import { useToast } from '../hooks/useToast'
+import { useV2Auth } from '../hooks/useV2Auth'
+import { useV2Firebase } from '../lib/firebase'
+import { createV2Api } from '../lib/api'
 
 type Reason = 'alert' | 'win' | 'skip'
 
 type TrainingCard = {
+  id?: string
   title: string
   icon: string
   tone: 'warm' | 'brand' | 'success' | 'gold' | 'purple'
@@ -37,6 +44,42 @@ const reasonStyle: Record<Reason, { bg: string; fg: string }> = {
 }
 
 export function Training() {
+  const firebase = useV2Firebase()
+  const auth = useV2Auth()
+  const toast = useToast()
+  const [cards, setCards] = React.useState<TrainingCard[]>(CARDS)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+
+  React.useEffect(() => {
+    if (!auth.user) {
+      return
+    }
+
+    let active = true
+    setLoading(true)
+    setError(null)
+    createV2Api(firebase).getTrainingRecommendations(auth.user.uid).then(nextCards => {
+      if (!active) return
+      setCards(nextCards.length > 0 ? nextCards : [])
+      setLoading(false)
+    }).catch(fetchError => {
+      if (!active) return
+      setError(fetchError as Error)
+      setLoading(false)
+    })
+
+    return () => { active = false }
+  }, [auth.user, firebase])
+
+  const handleCardAction = (card: TrainingCard) => {
+    if (card.reason === 'skip') {
+      toast.info(`${card.title} is optional for this coach right now.`)
+      return
+    }
+    toast.info(`${card.title} training opens from the existing CHALK training library.`)
+  }
+
   return (
     <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem' }}>
@@ -52,9 +95,31 @@ export function Training() {
         </div>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
-        {CARDS.map((c, i) => (
+      {error && (
+        <div style={{ color: 'var(--v2-warm-dark)', fontWeight: 600, marginBottom: '1rem' }}>Live training recommendations unavailable; showing local recommendations.</div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem' }}>
+        {loading ? [0, 1, 2].map(i => (
           <div key={i} style={{
+            background: 'var(--v2-white)',
+            borderRadius: 'var(--v2-radius)',
+            border: '1px solid var(--v2-line-soft)',
+            overflow: 'hidden',
+            boxShadow: 'var(--v2-shadow-sm)',
+            padding: '1.1rem'
+          }}>
+            <Skeleton height={120} style={{ marginBottom: '1rem' }} />
+            <Skeleton width="70%" height={20} style={{ marginBottom: '0.7rem' }} />
+            <Skeleton height={34} style={{ marginBottom: '0.8rem' }} />
+            <Skeleton width="45%" height={30} />
+          </div>
+        )) : cards.length === 0 ? (
+          <div style={{ gridColumn: '1 / -1' }}>
+            <EmptyState title="No training recommendations" description="Training recommendations will appear after recent observations and action plans are available." />
+          </div>
+        ) : cards.map((c, i) => (
+          <div key={c.id || i} style={{
             background: 'var(--v2-white)',
             borderRadius: 'var(--v2-radius)',
             border: '1px solid var(--v2-line-soft)',
@@ -88,6 +153,7 @@ export function Training() {
                   variant={c.ctaVariant === 'primary' ? 'primary' : 'default'}
                   size="sm"
                   style={{ flex: 1, justifyContent: 'center' }}
+                  onClick={() => handleCardAction(c)}
                 >
                   {c.ctaText}
                 </Button>

--- a/src/v2/pages/Training.tsx
+++ b/src/v2/pages/Training.tsx
@@ -8,6 +8,7 @@ import { useV2Firebase } from '../lib/firebase'
 import { createV2Api } from '../lib/api'
 
 type Reason = 'alert' | 'win' | 'skip'
+type TrainingView = 'recommended' | 'all' | 'completed'
 
 type TrainingCard = {
   id?: string
@@ -21,12 +22,12 @@ type TrainingCard = {
 }
 
 const CARDS: TrainingCard[] = [
-  { title: 'Smooth Transitions', icon: '⏱', tone: 'warm', reason: 'alert', reasonText: '⚠ 3 of your teachers flagged in this area', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
-  { title: 'Open-Ended Questions', icon: '🗣', tone: 'brand', reason: 'alert', reasonText: '⚠ Recurring theme in last 5 observations', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
-  { title: 'Classroom Climate', icon: '💚', tone: 'success', reason: 'win', reasonText: '✓ You scored in the top 10% — refresh available', ctaText: 'Refresh (8 min)' },
-  { title: 'Conscious Discipline Foundations', icon: '📚', tone: 'purple', reason: 'skip', reasonText: 'Completed in 2024 — skip unless needed', ctaText: 'Review notes' },
-  { title: 'Using Magic 9 effectively', icon: '📊', tone: 'gold', reason: 'skip', reasonText: 'Optional · recommended for new coaches', ctaText: 'Not now' },
-  { title: 'Writing better action plans', icon: '🎯', tone: 'warm', reason: 'alert', reasonText: '⚠ Your last 2 plans had no measurable goals', ctaText: 'Start (12 min)', ctaVariant: 'primary' }
+  { id: 'transitions', title: 'Smooth Transitions', icon: '⏱', tone: 'warm', reason: 'alert', reasonText: '⚠ 3 teachers flagged in this area', ctaText: 'Start (18 min)', ctaVariant: 'primary' },
+  { id: 'questions', title: 'Open-Ended Questions', icon: '🗣', tone: 'brand', reason: 'alert', reasonText: '⚠ Recurring theme in recent observations', ctaText: 'Start (24 min)', ctaVariant: 'primary' },
+  { id: 'climate', title: 'Classroom Climate', icon: '💚', tone: 'success', reason: 'win', reasonText: '✓ Refresh available', ctaText: 'Refresh (8 min)' },
+  { id: 'discipline', title: 'Conscious Discipline Foundations', icon: '📚', tone: 'purple', reason: 'skip', reasonText: 'Completed previously — skip unless needed', ctaText: 'Review notes' },
+  { id: 'magic9', title: 'Using Magic 9 effectively', icon: '📊', tone: 'gold', reason: 'skip', reasonText: 'Optional · recommended for new coaches', ctaText: 'Not now' },
+  { id: 'plans', title: 'Writing better action plans', icon: '🎯', tone: 'warm', reason: 'alert', reasonText: '⚠ Recent plans need measurable goals', ctaText: 'Start (12 min)', ctaVariant: 'primary' }
 ]
 
 const toneBg: Record<TrainingCard['tone'], string> = {
@@ -37,10 +38,23 @@ const toneBg: Record<TrainingCard['tone'], string> = {
   purple: 'linear-gradient(135deg, #6f39c4, #f0523d)'
 }
 
-const reasonStyle: Record<Reason, { bg: string; fg: string }> = {
+const reasonStyle: Record<Reason | 'complete', { bg: string; fg: string }> = {
   alert:   { bg: 'var(--v2-warm-soft)', fg: 'var(--v2-warm-dark)' },
   win:     { bg: 'var(--v2-success-soft)', fg: '#15803D' },
-  skip:    { bg: 'var(--v2-bg-soft)', fg: 'var(--v2-muted)' }
+  skip:    { bg: 'var(--v2-bg-soft)', fg: 'var(--v2-muted)' },
+  complete:{ bg: 'var(--v2-success-soft)', fg: 'var(--v2-success)' }
+}
+
+function storageKey(uid: string | undefined, suffix: string): string {
+  return `chalk-v2-training-${suffix}-${uid || 'preview'}`
+}
+
+function loadStoredIds(key: string): string[] {
+  try {
+    return JSON.parse(window.localStorage.getItem(key) || '[]')
+  } catch (error) {
+    return []
+  }
 }
 
 export function Training() {
@@ -50,6 +64,15 @@ export function Training() {
   const [cards, setCards] = React.useState<TrainingCard[]>(CARDS)
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<Error | null>(null)
+  const [view, setView] = React.useState<TrainingView>('recommended')
+  const [completedIds, setCompletedIds] = React.useState<string[]>(() => loadStoredIds(storageKey(undefined, 'completed')))
+  const [dismissedIds, setDismissedIds] = React.useState<string[]>(() => loadStoredIds(storageKey(undefined, 'dismissed')))
+
+  React.useEffect(() => {
+    const uid = auth.user?.uid
+    setCompletedIds(loadStoredIds(storageKey(uid, 'completed')))
+    setDismissedIds(loadStoredIds(storageKey(uid, 'dismissed')))
+  }, [auth.user])
 
   React.useEffect(() => {
     if (!auth.user) {
@@ -57,11 +80,18 @@ export function Training() {
     }
 
     let active = true
+    const api = createV2Api(firebase)
     setLoading(true)
     setError(null)
-    createV2Api(firebase).getTrainingRecommendations(auth.user.uid).then(nextCards => {
+
+    Promise.all([
+      api.getTrainingRecommendations(auth.user.uid),
+      api.getTrainingStatus(auth.user.uid)
+    ]).then(([nextCards, status]) => {
       if (!active) return
       setCards(nextCards.length > 0 ? nextCards : [])
+      setCompletedIds(Object.keys(status).filter(id => status[id]?.completedAt))
+      setDismissedIds(Object.keys(status).filter(id => status[id]?.dismissedAt && !status[id]?.completedAt))
       setLoading(false)
     }).catch(fetchError => {
       if (!active) return
@@ -72,26 +102,67 @@ export function Training() {
     return () => { active = false }
   }, [auth.user, firebase])
 
-  const handleCardAction = (card: TrainingCard) => {
-    if (card.reason === 'skip') {
-      toast.info(`${card.title} is optional for this coach right now.`)
-      return
-    }
-    toast.info(`${card.title} training opens from the existing CHALK training library.`)
+  React.useEffect(() => {
+    const uid = auth.user?.uid
+    window.localStorage.setItem(storageKey(uid, 'completed'), JSON.stringify(completedIds))
+    window.localStorage.setItem(storageKey(uid, 'dismissed'), JSON.stringify(dismissedIds))
+  }, [auth.user, completedIds, dismissedIds])
+
+  const visibleCards = cards.filter(card => {
+    const id = card.id || card.title
+    if (view === 'completed') return completedIds.includes(id)
+    if (view === 'recommended') return !completedIds.includes(id) && !dismissedIds.includes(id)
+    return !dismissedIds.includes(id) || completedIds.includes(id)
+  })
+
+  const markCompleted = (id: string) => {
+    setCompletedIds(current => current.includes(id) ? current : [...current, id])
+    setDismissedIds(current => current.filter(item => item !== id))
   }
 
+  const dismissCard = (id: string) => {
+    setDismissedIds(current => current.includes(id) ? current : [...current, id])
+  }
+
+  const handleCardAction = (card: TrainingCard) => {
+    const id = card.id || card.title
+    const api = createV2Api(firebase)
+
+    if (card.reason === 'skip') {
+      dismissCard(id)
+      if (auth.user) {
+        api.dismissTrainingRecommendation(auth.user.uid, id).catch(error => console.error('Unable to dismiss v2 training recommendation', error))
+      }
+      toast.info(`${card.title} skipped for this release view.`)
+      return
+    }
+
+    markCompleted(id)
+    if (auth.user) {
+      api.markTrainingCompleted(auth.user.uid, id).catch(error => console.error('Unable to mark v2 training complete', error))
+    }
+    toast.success(`${card.title} marked complete.`)
+  }
+
+  const tabStyle = (key: TrainingView): React.CSSProperties => ({
+    background: view === key ? 'var(--v2-ink)' : 'var(--v2-white)',
+    color: view === key ? 'var(--v2-white)' : 'var(--v2-ink-soft)',
+    border: '1px solid var(--v2-line)'
+  })
+
   return (
-    <div style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
+    <div className="v2-page" style={{ padding: '2rem 2.5rem', maxWidth: 1400, margin: '0 auto' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.75rem', flexWrap: 'wrap', gap: '1rem' }}>
         <div>
           <h1 style={{ fontSize: '1.7rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Training tailored to your coaching</h1>
           <div style={{ color: 'var(--v2-muted)', fontSize: '0.92rem', marginTop: '0.3rem' }}>
-            Based on patterns in your recent observations and action plans — recommended, not required.
+            Based on patterns in recent observations and action plans — recommended, not required.
           </div>
         </div>
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <Button>All training</Button>
-          <Button>Completed</Button>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Button style={tabStyle('recommended')} onClick={() => setView('recommended')}>Recommended</Button>
+          <Button style={tabStyle('all')} onClick={() => setView('all')}>All training</Button>
+          <Button style={tabStyle('completed')} onClick={() => setView('completed')}>Completed</Button>
         </div>
       </div>
 
@@ -114,53 +185,59 @@ export function Training() {
             <Skeleton height={34} style={{ marginBottom: '0.8rem' }} />
             <Skeleton width="45%" height={30} />
           </div>
-        )) : cards.length === 0 ? (
+        )) : visibleCards.length === 0 ? (
           <div style={{ gridColumn: '1 / -1' }}>
-            <EmptyState title="No training recommendations" description="Training recommendations will appear after recent observations and action plans are available." />
+            <EmptyState title="No training in this view" description="Completed and skipped recommendations are tracked per coach." />
           </div>
-        ) : cards.map((c, i) => (
-          <div key={c.id || i} style={{
-            background: 'var(--v2-white)',
-            borderRadius: 'var(--v2-radius)',
-            border: '1px solid var(--v2-line-soft)',
-            overflow: 'hidden',
-            boxShadow: 'var(--v2-shadow-sm)'
-          }}>
-            <div style={{
-              height: 120,
-              background: toneBg[c.tone],
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: '#fff',
-              fontSize: '2rem'
+        ) : visibleCards.map((c, i) => {
+          const id = c.id || c.title
+          const complete = completedIds.includes(id)
+          const statusStyle = complete ? reasonStyle.complete : reasonStyle[c.reason]
+          return (
+            <div key={id || i} style={{
+              background: 'var(--v2-white)',
+              borderRadius: 'var(--v2-radius)',
+              border: '1px solid var(--v2-line-soft)',
+              overflow: 'hidden',
+              boxShadow: 'var(--v2-shadow-sm)'
             }}>
-              {c.icon}
-            </div>
-            <div style={{ padding: '1.1rem' }}>
-              <h4 style={{ fontSize: '0.98rem', fontWeight: 600, marginBottom: '0.35rem' }}>{c.title}</h4>
               <div style={{
-                fontSize: '0.76rem',
-                padding: '0.4rem 0.6rem',
-                borderRadius: 6,
-                margin: '0.5rem 0 0.8rem',
-                fontWeight: 600,
-                background: reasonStyle[c.reason].bg,
-                color: reasonStyle[c.reason].fg
-              }}>{c.reasonText}</div>
-              <div style={{ display: 'flex', gap: '0.4rem' }}>
-                <Button
-                  variant={c.ctaVariant === 'primary' ? 'primary' : 'default'}
-                  size="sm"
-                  style={{ flex: 1, justifyContent: 'center' }}
-                  onClick={() => handleCardAction(c)}
-                >
-                  {c.ctaText}
-                </Button>
+                height: 120,
+                background: toneBg[c.tone],
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontSize: '2rem'
+              }}>
+                {c.icon}
+              </div>
+              <div style={{ padding: '1.1rem' }}>
+                <h4 style={{ fontSize: '0.98rem', fontWeight: 600, marginBottom: '0.35rem' }}>{c.title}</h4>
+                <div style={{
+                  fontSize: '0.76rem',
+                  padding: '0.4rem 0.6rem',
+                  borderRadius: 6,
+                  margin: '0.5rem 0 0.8rem',
+                  fontWeight: 600,
+                  background: statusStyle.bg,
+                  color: statusStyle.fg
+                }}>{complete ? '✓ Completed for this coach' : c.reasonText}</div>
+                <div style={{ display: 'flex', gap: '0.4rem' }}>
+                  <Button
+                    variant={complete ? 'default' : c.ctaVariant === 'primary' ? 'primary' : 'default'}
+                    size="sm"
+                    disabled={complete}
+                    style={{ flex: 1, justifyContent: 'center' }}
+                    onClick={() => handleCardAction(c)}
+                  >
+                    {complete ? 'Completed' : c.ctaText}
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,7 @@ module.exports = (env, argv) => {
                     'process.env.USE_LOCAL_FIRESTORE': process.env.REACT_APP_USE_LOCAL_FIRESTORE === 'true',
                     'process.env.USE_LOCAL_FUNCTIONS': process.env.REACT_APP_USE_LOCAL_FUNCTIONS === 'true',
                     'process.env.USE_LOCAL_AUTH'     : process.env.REACT_APP_USE_LOCAL_AUTH === 'true',
+                    'process.env.V2_PUBLIC_PREVIEW'  : process.env.REACT_APP_V2_PUBLIC_PREVIEW === 'true',
                     'process.env.FIREBASE_CONFIG'    : process.env.REACT_APP_FIREBASE_CONFIG
                 }),
                 new HtmlWebpackPlugin({


### PR DESCRIPTION
## Summary
- Adds CHALK 2.0 `/v2` preview behind the existing auth/preview gate.
- Closes release-readiness gaps: PII-safe demo data, observation completion/alignment, plan send confirmation, training completion/skip tracking, SW update notice, and responsive V2 shell polish.
- Keeps `REACT_APP_V2_PUBLIC_PREVIEW=false` so V2 is not publicly exposed by default.

## Verification
- `npm run staging`
- `npm run prod`
- Local smoke: `GET http://127.0.0.1:42020/v2/home` returned 200.

## Rollback
- Production rollback release exists at `prod-current-2026-05-29` targeting `1b4463024d2ec9e3de45d24d6ce2b82aebf6ec57`.

Closes CHALK-2
