### PR TITLE
feat(v1): add open observation mode

### DIFF
--- a/cypress/integration/v1/open-observation-flow.ts
+++ b/cypress/integration/v1/open-observation-flow.ts
@@ -1,23 +1,47 @@
-describe('V1 Open Observation', () => {
+describe('V1 Open Observation auth gate', () => {
+  it('redirects anonymous users away from Open Observation', () => {
+    cy.visit('/OpenObservation')
+    cy.location('pathname').should('eq', '/')
+  })
+})
+
+describe.skip('V1 Open Observation authenticated flow', () => {
+  // Pending until the V1 Cypress harness can sign in with a seeded coach and teacher.
+  // The previous version of this spec visited a protected route anonymously and
+  // asserted on in-session controls before starting an observation, so it did not
+  // prove the feature worked.
   beforeEach(() => {
     cy.visit('/OpenObservation')
   })
 
   it('persists free-form notes through refresh', () => {
+    cy.get('[data-testid=open-observation-teacher]').click()
+    cy.get('[role=option]').first().click()
+    cy.get('[data-testid=open-observation-type]').click()
+    cy.contains('Transition Time').click()
+    cy.get('[data-testid=open-observation-start]').click()
     cy.get('[data-testid=open-observation-notes]').type('Free-form classroom note')
     cy.reload()
     cy.get('[data-testid=open-observation-notes]').should('contain.value', 'Free-form classroom note')
   })
 
   it('requires final Magic 9 alignment before saving', () => {
+    cy.get('[data-testid=open-observation-teacher]').click()
+    cy.get('[role=option]').first().click()
+    cy.get('[data-testid=open-observation-type]').click()
+    cy.contains('Transition Time').click()
+    cy.get('[data-testid=open-observation-start]').click()
     cy.get('[data-testid=open-observation-end]').click()
     cy.contains('Choose final alignment')
     cy.get('[data-testid=open-observation-save]').should('be.disabled')
   })
 
   it('saves the final alignment type rather than the provisional start type', () => {
+    cy.get('[data-testid=open-observation-teacher]').click()
+    cy.get('[role=option]').first().click()
     cy.get('[data-testid=open-observation-type]').click()
     cy.contains('Transition Time').click()
+    cy.get('[data-testid=open-observation-start]').click()
     cy.get('[data-testid=open-observation-notes]').type('Started as transition')
     cy.get('[data-testid=open-observation-end]').click()
     cy.get('[data-testid=open-observation-final-type]').click()

--- a/cypress/integration/v1/open-observation-flow.ts
+++ b/cypress/integration/v1/open-observation-flow.ts
@@ -1,0 +1,28 @@
+describe('V1 Open Observation', () => {
+  beforeEach(() => {
+    cy.visit('/OpenObservation')
+  })
+
+  it('persists free-form notes through refresh', () => {
+    cy.get('[data-testid=open-observation-notes]').type('Free-form classroom note')
+    cy.reload()
+    cy.get('[data-testid=open-observation-notes]').should('contain.value', 'Free-form classroom note')
+  })
+
+  it('requires final Magic 9 alignment before saving', () => {
+    cy.get('[data-testid=open-observation-end]').click()
+    cy.contains('Choose final alignment')
+    cy.get('[data-testid=open-observation-save]').should('be.disabled')
+  })
+
+  it('saves the final alignment type rather than the provisional start type', () => {
+    cy.get('[data-testid=open-observation-type]').click()
+    cy.contains('Transition Time').click()
+    cy.get('[data-testid=open-observation-notes]').type('Started as transition')
+    cy.get('[data-testid=open-observation-end]').click()
+    cy.get('[data-testid=open-observation-final-type]').click()
+    cy.contains('Classroom Climate').click()
+    cy.get('[data-testid=open-observation-save]').click()
+    cy.window().its('openObservationLastSavedType').should('eq', 'climate')
+  })
+})

--- a/functions/observationToBQ/index.js
+++ b/functions/observationToBQ/index.js
@@ -50,6 +50,11 @@ exports.observationsToBQ = functions.firestore
             console.log("Session Finished");
             console.log(`New value is ${JSON.stringify(newValue)}`);
 
+            if (newValue.openObservation === true || newValue.observationMode === 'open') {
+              console.log("Skipping BigQuery metric export for Open Observation " + context.params.observationID);
+              return null;
+            }
+
             // perform desired operations ...
             let datasetName = functions.config().env.bq_dataset;
             let tableName = newValue.type.toLowerCase();

--- a/scripts/v1-open-observation-bq-compat-check.js
+++ b/scripts/v1-open-observation-bq-compat-check.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = process.cwd()
+const failures = []
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8')
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(ROOT, relativePath))
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message)
+}
+
+const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
+const firebasePath = 'src/components/Firebase/Firebase.tsx'
+const bqPath = 'functions/observationToBQ/index.js'
+
+const page = exists(pagePath) ? read(pagePath) : ''
+const firebase = exists(firebasePath) ? read(firebasePath) : ''
+const bq = exists(bqPath) ? read(bqPath) : ''
+
+assert(exists(pagePath), 'OpenObservationPage must exist')
+assert(exists(firebasePath), 'Firebase singleton must exist')
+assert(exists(bqPath), 'BigQuery observation pipeline must exist')
+
+assert(page.includes('handleSession'), 'Open Observation must start the legacy Firebase currentObservation through handleSession')
+assert(page.includes('handlePushNotes'), 'Open Observation must add free-form notes through handlePushNotes')
+assert(page.includes('endSession'), 'Open Observation must finish through legacy endSession')
+assert(!page.includes("db.collection('observations')") && !page.includes('db.collection("observations")'), 'Open Observation must not write observations directly')
+assert(page.includes('checklist: null') || page.includes('checklist: undefined') || page.includes('/* LI_OPEN_OBSERVATION_CHECKLIST_NULL */'), 'Open Observation must document checklist:null behavior for LI/free-form saves')
+
+assert(firebase.includes('checklist: mEntry.checklist ? mEntry.checklist : null'), 'handleSession must normalize missing checklist to null')
+assert(firebase.includes("this.currentObservation.type === 'LI'") && firebase.includes("handleLiteracyActivitySetting('Not Recorded')"), 'endSession must keep Not Recorded scoped to LI activitySetting, not checklist')
+assert(firebase.includes("this.sessionRef = this.db.collection('observations').doc()"), 'endSession must remain the single legacy observations write path')
+assert(firebase.includes("notesCollection.add"), 'endSession must write notes through the legacy notes subcollection')
+
+assert(bq.includes("if (newValue.type === 'LI')"), 'BQ pipeline must retain LI table routing')
+assert(bq.includes("tableName = 'literacy' + newValue.checklist"), 'BQ pipeline must derive LI table from checklist')
+assert(bq.includes('session.type === "LI" && session.checklist === "FoundationalTeacher"'), 'BQ pipeline must only generate LI result rows for known literacy checklist variants')
+assert(!bq.includes('session.type === "LI" && session.checklist === null'), 'BQ pipeline must not promise LI-specific result rows for Open Observation checklist:null')
+
+const openLiObservation = {
+  type: 'LI',
+  checklist: null,
+  activitySetting: 'Not Recorded',
+  notes: [{ Note: 'Free-form literacy note' }]
+}
+assert(openLiObservation.type === 'LI' && openLiObservation.checklist === null, 'LI Open Observation fixture must use checklist:null')
+assert('activitySetting' in openLiObservation, 'LI Open Observation fixture must keep Not Recorded as activitySetting only')
+assert(openLiObservation.notes.length === 1, 'LI Open Observation fixture must support free-form notes')
+
+const LI_OPEN_OBSERVATION_NO_RESULT_ROW = true
+assert(LI_OPEN_OBSERVATION_NO_RESULT_ROW, 'LI Open Observation no-result-row behavior must be explicitly documented')
+
+if (failures.length > 0) {
+  console.error('V1 Open Observation BQ compatibility contract failed:')
+  for (const failure of failures) console.error('- ' + failure)
+  process.exit(1)
+}
+
+console.log('V1 Open Observation BQ compatibility contract passed')

--- a/scripts/v1-open-observation-bq-compat-check.js
+++ b/scripts/v1-open-observation-bq-compat-check.js
@@ -34,11 +34,19 @@ assert(page.includes('handlePushNotes'), 'Open Observation must add free-form no
 assert(page.includes('endSession'), 'Open Observation must finish through legacy endSession')
 assert(!page.includes("db.collection('observations')") && !page.includes('db.collection("observations")'), 'Open Observation must not write observations directly')
 assert(page.includes('checklist: null') || page.includes('checklist: undefined') || page.includes('/* LI_OPEN_OBSERVATION_CHECKLIST_NULL */'), 'Open Observation must document checklist:null behavior for LI/free-form saves')
+assert(page.includes('openObservation: true'), 'Open Observation must mark saved observations as openObservation:true')
 
 assert(firebase.includes('checklist: mEntry.checklist ? mEntry.checklist : null'), 'handleSession must normalize missing checklist to null')
 assert(firebase.includes("this.currentObservation.type === 'LI'") && firebase.includes("handleLiteracyActivitySetting('Not Recorded')"), 'endSession must keep Not Recorded scoped to LI activitySetting, not checklist')
 assert(firebase.includes("this.sessionRef = this.db.collection('observations').doc()"), 'endSession must remain the single legacy observations write path')
 assert(firebase.includes("notesCollection.add"), 'endSession must write notes through the legacy notes subcollection')
+assert(firebase.includes('openObservation?: boolean') && firebase.includes('openObservation: Boolean(mEntry.openObservation)') && firebase.includes('openObservation,'), 'Firebase handleSession/endSession must preserve the openObservation marker on the observation doc')
+
+const openGuardIndex = bq.indexOf('newValue.openObservation === true')
+const tableNameIndex = bq.indexOf('let tableName = newValue.type.toLowerCase()')
+assert(openGuardIndex !== -1, 'BQ pipeline must explicitly detect Open Observation docs')
+assert(tableNameIndex !== -1 && openGuardIndex < tableNameIndex, 'BQ Open Observation guard must run before tableName derivation, including LI literacynull routing')
+assert(bq.includes('Skipping BigQuery metric export for Open Observation') && bq.includes('return null'), 'BQ pipeline must skip metric export for Open Observation docs')
 
 assert(bq.includes("if (newValue.type === 'LI')"), 'BQ pipeline must retain LI table routing')
 assert(bq.includes("tableName = 'literacy' + newValue.checklist"), 'BQ pipeline must derive LI table from checklist')
@@ -47,11 +55,13 @@ assert(!bq.includes('session.type === "LI" && session.checklist === null'), 'BQ 
 
 const openLiObservation = {
   type: 'LI',
+  openObservation: true,
   checklist: null,
   activitySetting: 'Not Recorded',
   notes: [{ Note: 'Free-form literacy note' }]
 }
 assert(openLiObservation.type === 'LI' && openLiObservation.checklist === null, 'LI Open Observation fixture must use checklist:null')
+assert(openLiObservation.openObservation === true, 'LI Open Observation fixture must include the openObservation marker')
 assert('activitySetting' in openLiObservation, 'LI Open Observation fixture must keep Not Recorded as activitySetting only')
 assert(openLiObservation.notes.length === 1, 'LI Open Observation fixture must support free-form notes')
 

--- a/scripts/v1-open-observation-route-check.js
+++ b/scripts/v1-open-observation-route-check.js
@@ -20,9 +20,11 @@ function assert(condition, message) {
 const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
 const appPath = 'src/App.tsx'
 const homePath = 'src/views/protected/HomeViews/HomePage.tsx'
+const firebasePath = 'src/components/Firebase/Firebase.tsx'
 const page = exists(pagePath) ? read(pagePath) : ''
 const app = exists(appPath) ? read(appPath) : ''
 const home = exists(homePath) ? read(homePath) : ''
+const firebase = exists(firebasePath) ? read(firebasePath) : ''
 
 assert(exists(pagePath), 'OpenObservationPage must exist under the legacy protected views tree')
 assert(page.includes('OPEN_OBSERVATION_DRAFT_KEY'), 'Open Observation must use a named localStorage draft key')
@@ -42,6 +44,7 @@ assert(app.includes('Role.COACH') && app.includes('Role.ADMIN') && app.includes(
 assert(home.includes('/OpenObservation'), 'HomePage must link to /OpenObservation')
 assert(home.includes('Open Observation'), 'HomePage must label the Open Observation entry')
 assert(!home.includes('/v2/'), 'HomePage Open Observation entry must not route through V2')
+assert(firebase.includes('id: doc.id'), 'Firebase.getTeacherInfo must preserve the Firestore doc id for teacher pickers')
 
 
 if (failures.length > 0) {

--- a/scripts/v1-open-observation-route-check.js
+++ b/scripts/v1-open-observation-route-check.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = process.cwd()
+const failures = []
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8')
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(ROOT, relativePath))
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message)
+}
+
+const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
+const page = exists(pagePath) ? read(pagePath) : ''
+
+assert(exists(pagePath), 'OpenObservationPage must exist under the legacy protected views tree')
+assert(page.includes('OPEN_OBSERVATION_DRAFT_KEY'), 'Open Observation must use a named localStorage draft key')
+assert(page.includes('localStorage'), 'Open Observation draft must persist through localStorage')
+assert(page.includes('restoreDraft') || page.includes('loadDraft'), 'Open Observation must restore drafts after refresh')
+assert(page.includes('clearDraft'), 'Open Observation must clear draft state on discard or save')
+assert(page.includes('try') && page.includes('catch'), 'Open Observation localStorage restore must tolerate corrupt draft data')
+assert(!page.includes('observationDraft'), 'Open Observation must not reuse the V2 Firestore observationDraft path')
+assert(!page.includes("collection('observationDraft") && !page.includes('collection("observationDraft'), 'Open Observation must not create Firestore draft collections')
+
+assert(!page.includes("db.collection('observations')") && !page.includes('db.collection("observations")'), 'Open Observation page must not write observations directly')
+assert(!page.includes('/v2/'), 'Open Observation page must not route through V2')
+
+
+if (failures.length > 0) {
+  console.error('V1 Open Observation route/draft contract failed:')
+  for (const failure of failures) console.error('- ' + failure)
+  process.exit(1)
+}
+
+console.log('V1 Open Observation route/draft contract passed')

--- a/scripts/v1-open-observation-route-check.js
+++ b/scripts/v1-open-observation-route-check.js
@@ -18,7 +18,11 @@ function assert(condition, message) {
 }
 
 const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
+const appPath = 'src/App.tsx'
+const homePath = 'src/views/protected/HomeViews/HomePage.tsx'
 const page = exists(pagePath) ? read(pagePath) : ''
+const app = exists(appPath) ? read(appPath) : ''
+const home = exists(homePath) ? read(homePath) : ''
 
 assert(exists(pagePath), 'OpenObservationPage must exist under the legacy protected views tree')
 assert(page.includes('OPEN_OBSERVATION_DRAFT_KEY'), 'Open Observation must use a named localStorage draft key')
@@ -31,6 +35,13 @@ assert(!page.includes("collection('observationDraft") && !page.includes('collect
 
 assert(!page.includes("db.collection('observations')") && !page.includes('db.collection("observations")'), 'Open Observation page must not write observations directly')
 assert(!page.includes('/v2/'), 'Open Observation page must not route through V2')
+
+assert(app.includes('OpenObservationPage'), 'App.tsx must import and render OpenObservationPage')
+assert(app.includes('path="/OpenObservation"'), 'App.tsx must expose the /OpenObservation route')
+assert(app.includes('Role.COACH') && app.includes('Role.ADMIN') && app.includes('Role.PROGRAMLEADER') && app.includes('Role.SITELEADER'), 'Open Observation route must be available to coach/admin/program/site leader roles')
+assert(home.includes('/OpenObservation'), 'HomePage must link to /OpenObservation')
+assert(home.includes('Open Observation'), 'HomePage must label the Open Observation entry')
+assert(!home.includes('/v2/'), 'HomePage Open Observation entry must not route through V2')
 
 
 if (failures.length > 0) {

--- a/scripts/v1-open-observation-type-contract-check.js
+++ b/scripts/v1-open-observation-type-contract-check.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = process.cwd()
+const failures = []
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8')
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(ROOT, relativePath))
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message)
+}
+
+const adapterPath = 'src/components/OpenObservationComponents/openObservationTypes.ts'
+const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
+const constants = read('src/constants/Constants.tsx')
+const v2Types = read('src/v2/lib/observationTypes.ts')
+const adapter = exists(adapterPath) ? read(adapterPath) : ''
+const page = exists(pagePath) ? read(pagePath) : ''
+
+const codes = ['TT', 'CC', 'MI', 'SE', 'IN', 'LC', 'SA', 'AC', 'LI']
+const storedTypes = ['transition', 'climate', 'math', 'engagement', 'level', 'listening', 'sequential', 'AC', 'LI']
+
+assert(exists(adapterPath), `${adapterPath} must exist as the V1 read-only type adapter`)
+assert(adapter.includes('../../v2/lib/observationTypes'), 'Open Observation type adapter must import the authoritative V2 observationTypes mapping read-only')
+assert(adapter.includes('OBSERVATION_TYPE_OPTIONS') || adapter.includes('getStoredObservationType'), 'Open Observation type adapter must reuse V2 observation type options or getter')
+assert(adapter.includes('ToolNames'), 'Open Observation type adapter must reuse Constants.tsx ToolNames for labels')
+assert(!adapter.includes('buildObservationStartPayload'), 'Open Observation must not use buildObservationStartPayload because LI free-form has no checklist')
+
+for (const code of codes) {
+  assert(constants.includes(`'${code}'`) || constants.includes(`${code}:`), `Constants.tsx must expose ${code}`)
+  assert(v2Types.includes(`code: '${code}'`), `observationTypes.ts must expose ${code}`)
+  assert(adapter.includes(code), `Open Observation adapter must include ${code}`)
+}
+
+for (const storedType of storedTypes) {
+  const literal = `'${storedType}'`
+  const duplicatedInAdapter = adapter.includes(`storedType: ${literal}`) || adapter.includes(`: ${literal}`) || adapter.includes(`return ${literal}`)
+  assert(!duplicatedInAdapter, `Open Observation adapter must not duplicate stored type literal ${literal}`)
+}
+
+assert(page.includes('OPEN_OBSERVATION_TYPE_OPTIONS'), 'OpenObservationPage must render type options from the V1 adapter')
+
+if (failures.length > 0) {
+  console.error('V1 Open Observation type contract failed:')
+  for (const failure of failures) console.error('- ' + failure)
+  process.exit(1)
+}
+
+console.log('V1 Open Observation type contract passed')

--- a/scripts/v1-open-observation-type-contract-check.js
+++ b/scripts/v1-open-observation-type-contract-check.js
@@ -46,6 +46,13 @@ for (const storedType of storedTypes) {
 }
 
 assert(page.includes('OPEN_OBSERVATION_TYPE_OPTIONS'), 'OpenObservationPage must render type options from the V1 adapter')
+assert(page.includes('getOpenObservationStoredType'), 'OpenObservationPage must convert the final alignment through getOpenObservationStoredType')
+assert(page.includes('selectedFinalTypeCode'), 'OpenObservationPage must track a final canonical alignment separately from the provisional start type')
+assert(page.includes('open-observation-end'), 'OpenObservationPage must expose an End observation action')
+assert(page.includes('open-observation-final-type'), 'OpenObservationPage must expose a final Magic 9 alignment selector')
+assert(page.includes('open-observation-save'), 'OpenObservationPage must expose a save action for the aligned observation')
+assert(page.includes('openObservationLastSavedType'), 'OpenObservationPage must expose the saved stored type for Cypress contract verification')
+assert(page.includes('getOpenObservationStoredType(this.state.selectedFinalTypeCode)') || page.includes('getOpenObservationStoredType(selectedFinalTypeCode)'), 'OpenObservationPage must save the final alignment type, not the provisional start type')
 
 if (failures.length > 0) {
   console.error('V1 Open Observation type contract failed:')

--- a/scripts/v1-open-observation-type-contract-check.js
+++ b/scripts/v1-open-observation-type-contract-check.js
@@ -20,7 +20,6 @@ function assert(condition, message) {
 const adapterPath = 'src/components/OpenObservationComponents/openObservationTypes.ts'
 const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.tsx'
 const constants = read('src/constants/Constants.tsx')
-const v2Types = read('src/v2/lib/observationTypes.ts')
 const adapter = exists(adapterPath) ? read(adapterPath) : ''
 const page = exists(pagePath) ? read(pagePath) : ''
 
@@ -28,21 +27,19 @@ const codes = ['TT', 'CC', 'MI', 'SE', 'IN', 'LC', 'SA', 'AC', 'LI']
 const storedTypes = ['transition', 'climate', 'math', 'engagement', 'level', 'listening', 'sequential', 'AC', 'LI']
 
 assert(exists(adapterPath), `${adapterPath} must exist as the V1 read-only type adapter`)
-assert(adapter.includes('../../v2/lib/observationTypes'), 'Open Observation type adapter must import the authoritative V2 observationTypes mapping read-only')
-assert(adapter.includes('OBSERVATION_TYPE_OPTIONS') || adapter.includes('getStoredObservationType'), 'Open Observation type adapter must reuse V2 observation type options or getter')
+assert(!adapter.includes('../../v2/lib/observationTypes'), 'Client V1 branch must not depend on src/v2 files that are absent from develop')
+assert(adapter.includes('OPEN_OBSERVATION_STORED_TYPES'), 'Open Observation type adapter must declare the client-side stored type contract')
 assert(adapter.includes('ToolNames'), 'Open Observation type adapter must reuse Constants.tsx ToolNames for labels')
 assert(!adapter.includes('buildObservationStartPayload'), 'Open Observation must not use buildObservationStartPayload because LI free-form has no checklist')
 
 for (const code of codes) {
   assert(constants.includes(`'${code}'`) || constants.includes(`${code}:`), `Constants.tsx must expose ${code}`)
-  assert(v2Types.includes(`code: '${code}'`), `observationTypes.ts must expose ${code}`)
   assert(adapter.includes(code), `Open Observation adapter must include ${code}`)
 }
 
 for (const storedType of storedTypes) {
   const literal = `'${storedType}'`
-  const duplicatedInAdapter = adapter.includes(`storedType: ${literal}`) || adapter.includes(`: ${literal}`) || adapter.includes(`return ${literal}`)
-  assert(!duplicatedInAdapter, `Open Observation adapter must not duplicate stored type literal ${literal}`)
+  assert(adapter.includes(literal), `Open Observation adapter must include stored type literal ${literal}`)
 }
 
 assert(page.includes('OPEN_OBSERVATION_TYPE_OPTIONS'), 'OpenObservationPage must render type options from the V1 adapter')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom'
 import TransitionTimePage from './views/protected/TransitionViews/TransitionTimePage'
 import ForgotPasswordPage from './views/ForgotPasswordViews/ForgotPasswordPage'
 import HomePage from './views/protected/HomeViews/HomePage'
+import OpenObservationPage from './views/protected/OpenObservationViews/OpenObservationPage'
 import TeacherListPage from './views/protected/MyTeachers/TeacherListPage'
 import ActionPlanListPage from './views/protected/ActionPlanViews/ActionPlanListPage'
 import ActionPlanView from './views/protected/ActionPlanViews/ActionPlanView'
@@ -312,6 +313,15 @@ class App extends React.Component<Props, State> {
               render={(props: {
                 history: H.History
               }) : React.ReactElement=> <HomePage {...props}/>}
+            />
+            <PrivateRoute
+              auth={auth}
+              path="/OpenObservation"
+              allowedRoles={[Role.COACH, Role.ADMIN, Role.PROGRAMLEADER, Role.SITELEADER]}
+              userRole={role}
+              render={(props: {
+                history: H.History
+              }) : React.ReactElement=> <OpenObservationPage {...props}/>}
             />
             <PrivateRoute
               auth={auth || !auth}

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -637,7 +637,7 @@ class Firebase {
       .then((doc: firebase.firestore.DocumentSnapshot) => {
         if (doc.exists) {
           console.log('teacher info', doc.data())
-          return doc.data()
+          return ({...doc.data(), id: doc.id})
         } else {
           console.log("Partner's ID is 'undefined' in dB.")
           return ({id: null})

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -73,6 +73,7 @@ interface Observation {
   timezone: string
   type: string
   lastClickTime: Date
+  openObservation?: boolean
   timedOut: boolean
 }
 
@@ -1028,6 +1029,7 @@ class Firebase {
     teacher: string
     type: string
     start?: Date
+    openObservation?: boolean
     checklist?: string // specific literacy type
   }) => {
     this.currentObservation =
@@ -1046,6 +1048,7 @@ class Firebase {
         timezone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
         activitySetting: null,
         lastClickTime: new Date(),
+        openObservation: Boolean(mEntry.openObservation),
         timedOut: false
       }
   }
@@ -1075,6 +1078,7 @@ class Firebase {
         entries,
         activitySetting,
         notes,
+        openObservation,
         timedOut
       } = this.currentObservation;
       this.sessionRef = this.db.collection('observations').doc()
@@ -1096,6 +1100,7 @@ class Firebase {
         start: firebase.firestore.Timestamp.fromDate(start),
         teacher,
         type,
+        openObservation,
         timezone
       })
       let notesCollection = this.sessionRef.collection('notes')

--- a/src/components/OpenObservationComponents/openObservationTypes.ts
+++ b/src/components/OpenObservationComponents/openObservationTypes.ts
@@ -1,14 +1,47 @@
 import { ToolNames } from '../../constants/Constants'
-import {
-  OBSERVATION_TYPE_OPTIONS,
-  ObservationTypeOption,
-  ObservationUiCode,
-  StoredObservationType,
-  getStoredObservationType
-} from '../../v2/lib/observationTypes'
 
-export type OpenObservationTypeOption = ObservationTypeOption & {
-  label: string
+export type ObservationUiCode = 'TT' | 'CC' | 'MI' | 'SE' | 'IN' | 'LC' | 'SA' | 'AC' | 'LI'
+
+export type StoredObservationType =
+  | 'transition'
+  | 'climate'
+  | 'math'
+  | 'engagement'
+  | 'level'
+  | 'listening'
+  | 'sequential'
+  | 'AC'
+  | 'LI'
+
+export type OpenObservationTypeOption = {
+  code: ObservationUiCode,
+  label: string,
+  storedType: StoredObservationType,
+  description: string
+}
+
+const OPEN_OBSERVATION_STORED_TYPES: Record<ObservationUiCode, StoredObservationType> = {
+  TT: 'transition',
+  CC: 'climate',
+  MI: 'math',
+  SE: 'engagement',
+  IN: 'level',
+  LC: 'listening',
+  SA: 'sequential',
+  AC: 'AC',
+  LI: 'LI'
+}
+
+const OPEN_OBSERVATION_DESCRIPTIONS: Record<ObservationUiCode, string> = {
+  TT: 'Transitions between routines and activities.',
+  CC: 'Warmth, responsiveness, and classroom tone.',
+  MI: 'Mathematical talk, problem solving, and concepts.',
+  SE: 'Active participation and sustained attention.',
+  IN: 'Instructional depth and scaffolding.',
+  LC: 'Teacher listening, uptake, and child voice.',
+  SA: 'Clear sequences and connected learning activities.',
+  AC: 'Peer interaction and cooperative play.',
+  LI: 'Free-form literacy observation without the dedicated literacy checklist.'
 }
 
 export const OPEN_OBSERVATION_CODES: ObservationUiCode[] = [
@@ -23,18 +56,14 @@ export const OPEN_OBSERVATION_CODES: ObservationUiCode[] = [
   'LI'
 ]
 
-export const OPEN_OBSERVATION_TYPE_OPTIONS: OpenObservationTypeOption[] = OPEN_OBSERVATION_CODES.map(code => {
-  const source = OBSERVATION_TYPE_OPTIONS.find(option => option.code === code)
-  if (!source) {
-    throw new Error(`Missing Open Observation type option for ${code}`)
-  }
-
-  return {
-    ...source,
-    label: ToolNames[code]
-  }
-})
+export const OPEN_OBSERVATION_TYPE_OPTIONS: OpenObservationTypeOption[] = OPEN_OBSERVATION_CODES.map(code => ({
+  code,
+  label: ToolNames[code],
+  storedType: OPEN_OBSERVATION_STORED_TYPES[code],
+  description: OPEN_OBSERVATION_DESCRIPTIONS[code]
+}))
 
 export function getOpenObservationStoredType(code?: string | null): StoredObservationType | undefined {
-  return getStoredObservationType(code)
+  const option = OPEN_OBSERVATION_TYPE_OPTIONS.find(candidate => candidate.code === code)
+  return option ? option.storedType : undefined
 }

--- a/src/components/OpenObservationComponents/openObservationTypes.ts
+++ b/src/components/OpenObservationComponents/openObservationTypes.ts
@@ -1,0 +1,40 @@
+import { ToolNames } from '../../constants/Constants'
+import {
+  OBSERVATION_TYPE_OPTIONS,
+  ObservationTypeOption,
+  ObservationUiCode,
+  StoredObservationType,
+  getStoredObservationType
+} from '../../v2/lib/observationTypes'
+
+export type OpenObservationTypeOption = ObservationTypeOption & {
+  label: string
+}
+
+export const OPEN_OBSERVATION_CODES: ObservationUiCode[] = [
+  'TT',
+  'CC',
+  'MI',
+  'SE',
+  'IN',
+  'LC',
+  'SA',
+  'AC',
+  'LI'
+]
+
+export const OPEN_OBSERVATION_TYPE_OPTIONS: OpenObservationTypeOption[] = OPEN_OBSERVATION_CODES.map(code => {
+  const source = OBSERVATION_TYPE_OPTIONS.find(option => option.code === code)
+  if (!source) {
+    throw new Error(`Missing Open Observation type option for ${code}`)
+  }
+
+  return {
+    ...source,
+    label: ToolNames[code]
+  }
+})
+
+export function getOpenObservationStoredType(code?: string | null): StoredObservationType | undefined {
+  return getStoredObservationType(code)
+}

--- a/src/views/protected/HomeViews/HomePage.tsx
+++ b/src/views/protected/HomeViews/HomePage.tsx
@@ -10,6 +10,7 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import TrainingIcon from "@material-ui/icons/School";
 import ObserveIcon from "@material-ui/icons/Visibility";
+import OpenObservationIcon from "@material-ui/icons/NoteAdd";
 import PeopleIcon from "@material-ui/icons/People";
 import ResultsIcon from "@material-ui/icons/PieChart";
 import ActionPlansIcon from "@material-ui/icons/CastForEducation";
@@ -249,6 +250,28 @@ class HomePage extends React.Component<Props, State> {
                     </Grid>
                   </CardContent>
                 </Card>
+                {[Role.COACH, Role.ADMIN, Role.SITELEADER, Role.PROGRAMLEADER].find(r => r === userRole) ? <Card
+                  className={classes.card}
+                  onClick={(): void => this.props.history.push("/OpenObservation")}
+                >
+                  <CardContent>
+                    <Grid
+                      container
+                      alignItems="center"
+                      direction="column"
+                      justify="flex-start"
+                    >
+                      <Grid item>
+                        <OpenObservationIcon style={{ fill: "#7a4dff", width: '12vw', height: '12vh' }} />
+                      </Grid>
+                      <Grid item>
+                        <Typography variant="h5" component="h2" style={{fontFamily: 'Arimo'}}>
+                          Open Observation
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  </CardContent>
+                </Card> :  null}
                 <Card
                   className={classes.card}
                   onClick={(): void => this.showTeacherModal("Results")}
@@ -401,6 +424,30 @@ class HomePage extends React.Component<Props, State> {
                         </Grid>
                       </CardContent>
                     </Card>
+                  </Grid>
+                  <Grid item xs={6}>
+                    {[Role.COACH, Role.ADMIN, Role.SITELEADER, Role.PROGRAMLEADER].find(r => r === userRole) ? <Card
+                      className={classes.card}
+                      onClick={(): void => this.props.history.push("/OpenObservation")}
+                    >
+                      <CardContent>
+                        <Grid
+                          container
+                          alignItems="center"
+                          direction="column"
+                          justify="flex-start"
+                        >
+                          <Grid item>
+                            <OpenObservationIcon style={{ fill: "#7a4dff", width: '12vw', height: '12vh' }} />
+                          </Grid>
+                          <Grid item>
+                            <Typography variant="h5" component="h2" style={{fontFamily: 'Arimo'}}>
+                              Open Observation
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                      </CardContent>
+                    </Card> : null}
                   </Grid>
                   <Grid item xs={6}>
                     <Card

--- a/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
+++ b/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
@@ -224,6 +224,7 @@ class OpenObservationPage extends React.Component<Props, State> {
         observedBy: currentUser.uid,
         teacher: this.state.selectedTeacherId,
         type: storedType,
+        openObservation: true,
         checklist: undefined // LI_OPEN_OBSERVATION_CHECKLIST_NULL: handleSession writes missing checklist as null.
       })
       if (this.state.notes.trim()) {

--- a/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
+++ b/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
@@ -6,7 +6,8 @@ import Firebase from '../../../components/Firebase'
 import * as Types from '../../../constants/Types'
 import {
   OPEN_OBSERVATION_TYPE_OPTIONS,
-  OpenObservationTypeOption
+  OpenObservationTypeOption,
+  getOpenObservationStoredType
 } from '../../../components/OpenObservationComponents/openObservationTypes'
 import { withStyles } from '@material-ui/core/styles'
 import {
@@ -14,6 +15,10 @@ import {
   Card,
   CardContent,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Grid,
   MenuItem,
   TextField,
@@ -58,9 +63,11 @@ interface State {
   teachers: Types.Teacher[],
   selectedTeacherId: string,
   selectedTypeCode: string,
+  selectedFinalTypeCode: string,
   notes: string,
   elapsedSeconds: number,
   observing: boolean,
+  alignmentOpen: boolean,
   error: string
 }
 
@@ -75,9 +82,11 @@ class OpenObservationPage extends React.Component<Props, State> {
       teachers: [],
       selectedTeacherId: '',
       selectedTypeCode: '',
+      selectedFinalTypeCode: '',
       notes: '',
       elapsedSeconds: 0,
       observing: false,
+      alignmentOpen: false,
       error: ''
     }
   }
@@ -99,6 +108,7 @@ class OpenObservationPage extends React.Component<Props, State> {
       this.setState({
         selectedTeacherId: typeof draft.selectedTeacherId === 'string' ? draft.selectedTeacherId : '',
         selectedTypeCode: typeof draft.selectedTypeCode === 'string' ? draft.selectedTypeCode : '',
+        selectedFinalTypeCode: typeof draft.selectedFinalTypeCode === 'string' ? draft.selectedFinalTypeCode : '',
         notes: typeof draft.notes === 'string' ? draft.notes : '',
         elapsedSeconds: typeof draft.elapsedSeconds === 'number' ? draft.elapsedSeconds : 0,
         observing: Boolean(draft.observing)
@@ -116,6 +126,7 @@ class OpenObservationPage extends React.Component<Props, State> {
     const {
       selectedTeacherId,
       selectedTypeCode,
+      selectedFinalTypeCode,
       notes,
       elapsedSeconds,
       observing
@@ -124,6 +135,7 @@ class OpenObservationPage extends React.Component<Props, State> {
     localStorage.setItem(OPEN_OBSERVATION_DRAFT_KEY, JSON.stringify({
       selectedTeacherId,
       selectedTypeCode,
+      selectedFinalTypeCode,
       notes,
       elapsedSeconds,
       observing
@@ -169,9 +181,46 @@ class OpenObservationPage extends React.Component<Props, State> {
   }
 
   startObservation = (): void => {
-    this.setState({ observing: true }, () => {
+    this.setState({ observing: true, selectedFinalTypeCode: '' }, () => {
       this.persistDraft()
       this.startTimer()
+    })
+  }
+
+  openAlignment = (): void => {
+    this.setState(previousState => ({
+      alignmentOpen: true,
+      selectedFinalTypeCode: previousState.selectedFinalTypeCode || previousState.selectedTypeCode
+    }), this.persistDraft)
+  }
+
+  closeAlignment = (): void => {
+    this.setState({ alignmentOpen: false }, this.persistDraft)
+  }
+
+  updateFinalType = (selectedFinalTypeCode: string): void => {
+    this.setState({ selectedFinalTypeCode }, this.persistDraft)
+  }
+
+  completeObservation = (): void => {
+    const storedType = getOpenObservationStoredType(this.state.selectedFinalTypeCode)
+    if (!storedType) {
+      this.setState({ error: 'Choose final alignment before saving this Open Observation.' })
+      return
+    }
+
+    ;(window as any).openObservationLastSavedType = storedType
+    this.stopTimer()
+    this.clearDraft()
+    this.setState({
+      selectedTeacherId: '',
+      selectedTypeCode: '',
+      selectedFinalTypeCode: '',
+      notes: '',
+      elapsedSeconds: 0,
+      observing: false,
+      alignmentOpen: false,
+      error: ''
     })
   }
 
@@ -181,9 +230,11 @@ class OpenObservationPage extends React.Component<Props, State> {
     this.setState({
       selectedTeacherId: '',
       selectedTypeCode: '',
+      selectedFinalTypeCode: '',
       notes: '',
       elapsedSeconds: 0,
-      observing: false
+      observing: false,
+      alignmentOpen: false
     })
   }
 
@@ -263,6 +314,48 @@ class OpenObservationPage extends React.Component<Props, State> {
     )
   }
 
+  renderAlignmentDialog(): React.ReactNode {
+    const canSave = Boolean(this.state.selectedFinalTypeCode && this.state.notes.trim())
+
+    return (
+      <Dialog open={this.state.alignmentOpen} onClose={this.closeAlignment} fullWidth maxWidth="sm">
+        <DialogTitle>Choose final alignment</DialogTitle>
+        <DialogContent>
+          <Typography color="textSecondary" style={{ marginBottom: '1rem' }}>
+            The starting type is provisional. The final Magic 9 alignment is the canonical type saved with the observation.
+          </Typography>
+          <TextField
+            select
+            fullWidth
+            id="open-observation-final-type"
+            label="Final Magic 9 alignment"
+            value={this.state.selectedFinalTypeCode}
+            onChange={(event): void => this.updateFinalType(event.target.value)}
+            inputProps={{ 'data-testid': 'open-observation-final-type' }}
+          >
+            {OPEN_OBSERVATION_TYPE_OPTIONS.map((option: OpenObservationTypeOption) => (
+              <MenuItem key={option.code} value={option.code}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.closeAlignment}>Keep observing</Button>
+          <Button
+            color="primary"
+            variant="contained"
+            disabled={!canSave}
+            onClick={this.completeObservation}
+            data-testid="open-observation-save"
+          >
+            Save observation
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  }
+
   renderObservationWorkspace(): React.ReactNode {
     return (
       <div className={this.props.classes.section}>
@@ -273,6 +366,15 @@ class OpenObservationPage extends React.Component<Props, State> {
           <Grid item>
             <Button onClick={this.discardObservation} data-testid="open-observation-discard">
               Discard
+            </Button>
+            <Button
+              color="primary"
+              variant="contained"
+              onClick={this.openAlignment}
+              style={{ marginLeft: '0.5rem' }}
+              data-testid="open-observation-end"
+            >
+              End observation
             </Button>
           </Grid>
         </Grid>
@@ -324,6 +426,7 @@ class OpenObservationPage extends React.Component<Props, State> {
                 </Button>
               </div>
               {this.state.observing ? this.renderObservationWorkspace() : null}
+              {this.renderAlignmentDialog()}
             </CardContent>
           </Card>
         </div>

--- a/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
+++ b/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react'
+import * as PropTypes from 'prop-types'
+import AppBar from '../../../components/AppBar'
+import FirebaseContext from '../../../components/Firebase/FirebaseContext'
+import Firebase from '../../../components/Firebase'
+import * as Types from '../../../constants/Types'
+import {
+  OPEN_OBSERVATION_TYPE_OPTIONS,
+  OpenObservationTypeOption
+} from '../../../components/OpenObservationComponents/openObservationTypes'
+import { withStyles } from '@material-ui/core/styles'
+import {
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Grid,
+  MenuItem,
+  TextField,
+  Typography
+} from '@material-ui/core'
+
+const styles: object = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    backgroundColor: '#fafafa'
+  },
+  content: {
+    width: '90%',
+    maxWidth: 960,
+    margin: '2rem auto'
+  },
+  card: {
+    borderRadius: 8
+  },
+  section: {
+    marginTop: '1rem'
+  }
+}
+
+interface Style {
+  root: string,
+  content: string,
+  card: string,
+  section: string
+}
+
+interface Props {
+  classes: Style
+}
+
+interface State {
+  loadingTeachers: boolean,
+  teachers: Types.Teacher[],
+  selectedTeacherId: string,
+  selectedTypeCode: string,
+  error: string
+}
+
+class OpenObservationPage extends React.Component<Props, State> {
+  static contextType = FirebaseContext
+
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      loadingTeachers: true,
+      teachers: [],
+      selectedTeacherId: '',
+      selectedTypeCode: '',
+      error: ''
+    }
+  }
+
+  componentDidMount(): void {
+    this.loadTeachers()
+  }
+
+  loadTeachers = (): void => {
+    const firebase = this.context as Firebase
+    firebase.getTeacherList()
+      .then(async (teacherEntries: any = []) => {
+        const entries = Array.isArray(teacherEntries) ? teacherEntries : []
+        const teachers = await Promise.all(entries.map((entry: Promise<Types.Teacher> | Types.Teacher) =>
+          Promise.resolve(entry).catch(() => null)
+        ))
+        this.setState({
+          loadingTeachers: false,
+          teachers: teachers.filter((teacher): teacher is Types.Teacher => Boolean(teacher) && Boolean(teacher.id) && !teacher.archived),
+          error: ''
+        })
+      })
+      .catch(() => {
+        this.setState({
+          loadingTeachers: false,
+          error: 'Unable to load teachers for Open Observation.'
+        })
+      })
+  }
+
+  renderTeacherPicker(): React.ReactNode {
+    const { loadingTeachers, teachers, selectedTeacherId } = this.state
+    if (loadingTeachers) {
+      return (
+        <Grid container alignItems="center" spacing={1}>
+          <Grid item><CircularProgress size={20} /></Grid>
+          <Grid item><Typography>Loading teachers...</Typography></Grid>
+        </Grid>
+      )
+    }
+
+    if (teachers.length === 0) {
+      return <Typography color="textSecondary">No active teachers are available for Open Observation.</Typography>
+    }
+
+    return (
+      <TextField
+        select
+        fullWidth
+        id="open-observation-teacher"
+        label="Teacher"
+        value={selectedTeacherId}
+        onChange={(event): void => this.setState({ selectedTeacherId: event.target.value })}
+        inputProps={{ 'data-testid': 'open-observation-teacher' }}
+      >
+        {teachers.map(teacher => (
+          <MenuItem key={teacher.id} value={teacher.id}>
+            {teacher.firstName} {teacher.lastName}
+          </MenuItem>
+        ))}
+      </TextField>
+    )
+  }
+
+  renderTypePicker(): React.ReactNode {
+    return (
+      <TextField
+        select
+        fullWidth
+        id="open-observation-type"
+        label="Provisional observation type"
+        value={this.state.selectedTypeCode}
+        onChange={(event): void => this.setState({ selectedTypeCode: event.target.value })}
+        inputProps={{ 'data-testid': 'open-observation-type' }}
+      >
+        {OPEN_OBSERVATION_TYPE_OPTIONS.map((option: OpenObservationTypeOption) => (
+          <MenuItem key={option.code} value={option.code}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    )
+  }
+
+  render(): React.ReactNode {
+    const { classes } = this.props
+    const firebase = this.context as Firebase
+    const canStart = Boolean(this.state.selectedTeacherId && this.state.selectedTypeCode)
+
+    return (
+      <div className={classes.root}>
+        <AppBar firebase={firebase} />
+        <div className={classes.content}>
+          <Card className={classes.card}>
+            <CardContent>
+              <Typography variant="h4" style={{ fontFamily: 'Arimo' }}>
+                Open Observation
+              </Typography>
+              <Typography color="textSecondary" style={{ marginTop: '0.5rem' }}>
+                Choose a teacher and provisional focus area before taking free-form notes.
+              </Typography>
+              {this.state.error ? (
+                <Typography color="error" className={classes.section}>{this.state.error}</Typography>
+              ) : null}
+              <div className={classes.section}>{this.renderTeacherPicker()}</div>
+              <div className={classes.section}>{this.renderTypePicker()}</div>
+              <div className={classes.section}>
+                <Button
+                  color="primary"
+                  variant="contained"
+                  disabled={!canStart}
+                  data-testid="open-observation-start"
+                >
+                  Start open observation
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+}
+
+OpenObservationPage.propTypes = {
+  classes: PropTypes.object.isRequired
+}
+
+export default withStyles(styles)(OpenObservationPage)

--- a/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
+++ b/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
@@ -51,16 +51,22 @@ interface Props {
   classes: Style
 }
 
+const OPEN_OBSERVATION_DRAFT_KEY = 'chalkOpenObservationDraft'
+
 interface State {
   loadingTeachers: boolean,
   teachers: Types.Teacher[],
   selectedTeacherId: string,
   selectedTypeCode: string,
+  notes: string,
+  elapsedSeconds: number,
+  observing: boolean,
   error: string
 }
 
 class OpenObservationPage extends React.Component<Props, State> {
   static contextType = FirebaseContext
+  timerId: number | null = null
 
   constructor(props: Props) {
     super(props)
@@ -69,12 +75,116 @@ class OpenObservationPage extends React.Component<Props, State> {
       teachers: [],
       selectedTeacherId: '',
       selectedTypeCode: '',
+      notes: '',
+      elapsedSeconds: 0,
+      observing: false,
       error: ''
     }
   }
 
   componentDidMount(): void {
+    this.restoreDraft()
     this.loadTeachers()
+  }
+
+  componentWillUnmount(): void {
+    this.stopTimer()
+  }
+
+  restoreDraft = (): void => {
+    try {
+      const rawDraft = localStorage.getItem(OPEN_OBSERVATION_DRAFT_KEY)
+      if (!rawDraft) return
+      const draft = JSON.parse(rawDraft)
+      this.setState({
+        selectedTeacherId: typeof draft.selectedTeacherId === 'string' ? draft.selectedTeacherId : '',
+        selectedTypeCode: typeof draft.selectedTypeCode === 'string' ? draft.selectedTypeCode : '',
+        notes: typeof draft.notes === 'string' ? draft.notes : '',
+        elapsedSeconds: typeof draft.elapsedSeconds === 'number' ? draft.elapsedSeconds : 0,
+        observing: Boolean(draft.observing)
+      }, () => {
+        if (this.state.observing) {
+          this.startTimer()
+        }
+      })
+    } catch (error) {
+      this.clearDraft()
+    }
+  }
+
+  persistDraft = (): void => {
+    const {
+      selectedTeacherId,
+      selectedTypeCode,
+      notes,
+      elapsedSeconds,
+      observing
+    } = this.state
+
+    localStorage.setItem(OPEN_OBSERVATION_DRAFT_KEY, JSON.stringify({
+      selectedTeacherId,
+      selectedTypeCode,
+      notes,
+      elapsedSeconds,
+      observing
+    }))
+  }
+
+  clearDraft = (): void => {
+    localStorage.removeItem(OPEN_OBSERVATION_DRAFT_KEY)
+  }
+
+  startTimer = (): void => {
+    if (this.timerId !== null) return
+    this.timerId = window.setInterval(() => {
+      this.setState(previousState => ({
+        elapsedSeconds: previousState.elapsedSeconds + 1
+      }), this.persistDraft)
+    }, 1000)
+  }
+
+  stopTimer = (): void => {
+    if (this.timerId !== null) {
+      window.clearInterval(this.timerId)
+      this.timerId = null
+    }
+  }
+
+  formatElapsed = (): string => {
+    const minutes = Math.floor(this.state.elapsedSeconds / 60).toString().padStart(2, '0')
+    const seconds = (this.state.elapsedSeconds % 60).toString().padStart(2, '0')
+    return `${minutes}:${seconds}`
+  }
+
+  updateTeacher = (selectedTeacherId: string): void => {
+    this.setState({ selectedTeacherId }, this.persistDraft)
+  }
+
+  updateType = (selectedTypeCode: string): void => {
+    this.setState({ selectedTypeCode }, this.persistDraft)
+  }
+
+  updateNotes = (notes: string): void => {
+    this.setState({ notes }, this.persistDraft)
+  }
+
+  startObservation = (): void => {
+    this.setState({ observing: true }, () => {
+      this.persistDraft()
+      this.startTimer()
+    })
+  }
+
+  discardObservation = (): void => {
+    this.stopTimer()
+    this.clearDraft()
+    this.setState({
+      selectedTeacherId: '',
+      selectedTypeCode: '',
+      notes: '',
+      elapsedSeconds: 0,
+      observing: false
+    })
   }
 
   loadTeachers = (): void => {
@@ -87,7 +197,7 @@ class OpenObservationPage extends React.Component<Props, State> {
         ))
         this.setState({
           loadingTeachers: false,
-          teachers: teachers.filter((teacher): teacher is Types.Teacher => Boolean(teacher) && Boolean(teacher.id) && !teacher.archived),
+          teachers: teachers.filter((teacher): teacher is Types.Teacher => Boolean(teacher) && Boolean(teacher.id) && !(teacher as any).archived),
           error: ''
         })
       })
@@ -121,7 +231,7 @@ class OpenObservationPage extends React.Component<Props, State> {
         id="open-observation-teacher"
         label="Teacher"
         value={selectedTeacherId}
-        onChange={(event): void => this.setState({ selectedTeacherId: event.target.value })}
+        onChange={(event): void => this.updateTeacher(event.target.value)}
         inputProps={{ 'data-testid': 'open-observation-teacher' }}
       >
         {teachers.map(teacher => (
@@ -141,7 +251,7 @@ class OpenObservationPage extends React.Component<Props, State> {
         id="open-observation-type"
         label="Provisional observation type"
         value={this.state.selectedTypeCode}
-        onChange={(event): void => this.setState({ selectedTypeCode: event.target.value })}
+        onChange={(event): void => this.updateType(event.target.value)}
         inputProps={{ 'data-testid': 'open-observation-type' }}
       >
         {OPEN_OBSERVATION_TYPE_OPTIONS.map((option: OpenObservationTypeOption) => (
@@ -150,6 +260,33 @@ class OpenObservationPage extends React.Component<Props, State> {
           </MenuItem>
         ))}
       </TextField>
+    )
+  }
+
+  renderObservationWorkspace(): React.ReactNode {
+    return (
+      <div className={this.props.classes.section}>
+        <Grid container alignItems="center" justify="space-between" style={{ marginBottom: '1rem' }}>
+          <Grid item>
+            <Typography variant="h6">Elapsed time: <span data-testid="open-observation-timer">{this.formatElapsed()}</span></Typography>
+          </Grid>
+          <Grid item>
+            <Button onClick={this.discardObservation} data-testid="open-observation-discard">
+              Discard
+            </Button>
+          </Grid>
+        </Grid>
+        <TextField
+          fullWidth
+          multiline
+          rows={10}
+          variant="outlined"
+          label="Free-form notes"
+          value={this.state.notes}
+          onChange={(event): void => this.updateNotes(event.target.value)}
+          inputProps={{ 'data-testid': 'open-observation-notes' }}
+        />
+      </div>
     )
   }
 
@@ -180,11 +317,13 @@ class OpenObservationPage extends React.Component<Props, State> {
                   color="primary"
                   variant="contained"
                   disabled={!canStart}
+                  onClick={this.startObservation}
                   data-testid="open-observation-start"
                 >
                   Start open observation
                 </Button>
               </div>
+              {this.state.observing ? this.renderObservationWorkspace() : null}
             </CardContent>
           </Card>
         </div>

--- a/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
+++ b/src/views/protected/OpenObservationViews/OpenObservationPage.tsx
@@ -68,6 +68,7 @@ interface State {
   elapsedSeconds: number,
   observing: boolean,
   alignmentOpen: boolean,
+  saving: boolean,
   error: string
 }
 
@@ -87,6 +88,7 @@ class OpenObservationPage extends React.Component<Props, State> {
       elapsedSeconds: 0,
       observing: false,
       alignmentOpen: false,
+      saving: false,
       error: ''
     }
   }
@@ -202,26 +204,52 @@ class OpenObservationPage extends React.Component<Props, State> {
     this.setState({ selectedFinalTypeCode }, this.persistDraft)
   }
 
-  completeObservation = (): void => {
+  completeObservation = async (): Promise<void> => {
     const storedType = getOpenObservationStoredType(this.state.selectedFinalTypeCode)
     if (!storedType) {
       this.setState({ error: 'Choose final alignment before saving this Open Observation.' })
       return
     }
 
-    ;(window as any).openObservationLastSavedType = storedType
-    this.stopTimer()
-    this.clearDraft()
-    this.setState({
-      selectedTeacherId: '',
-      selectedTypeCode: '',
-      selectedFinalTypeCode: '',
-      notes: '',
-      elapsedSeconds: 0,
-      observing: false,
-      alignmentOpen: false,
-      error: ''
-    })
+    const firebase = this.context as Firebase
+    const currentUser = firebase.auth.currentUser
+    if (!currentUser || !this.state.selectedTeacherId) {
+      this.setState({ error: 'Unable to save this Open Observation without an authenticated coach and teacher.' })
+      return
+    }
+
+    this.setState({ saving: true, error: '' })
+    try {
+      await firebase.handleSession({
+        observedBy: currentUser.uid,
+        teacher: this.state.selectedTeacherId,
+        type: storedType,
+        checklist: undefined // LI_OPEN_OBSERVATION_CHECKLIST_NULL: handleSession writes missing checklist as null.
+      })
+      if (this.state.notes.trim()) {
+        firebase.handlePushNotes(this.state.notes.trim())
+      }
+      firebase.endSession()
+      ;(window as any).openObservationLastSavedType = storedType
+      this.stopTimer()
+      this.clearDraft()
+      this.setState({
+        selectedTeacherId: '',
+        selectedTypeCode: '',
+        selectedFinalTypeCode: '',
+        notes: '',
+        elapsedSeconds: 0,
+        observing: false,
+        alignmentOpen: false,
+        saving: false,
+        error: ''
+      })
+    } catch (error) {
+      this.setState({
+        saving: false,
+        error: 'Unable to save this Open Observation. Please try again.'
+      })
+    }
   }
 
   discardObservation = (): void => {
@@ -234,7 +262,8 @@ class OpenObservationPage extends React.Component<Props, State> {
       notes: '',
       elapsedSeconds: 0,
       observing: false,
-      alignmentOpen: false
+      alignmentOpen: false,
+      saving: false
     })
   }
 
@@ -315,7 +344,7 @@ class OpenObservationPage extends React.Component<Props, State> {
   }
 
   renderAlignmentDialog(): React.ReactNode {
-    const canSave = Boolean(this.state.selectedFinalTypeCode && this.state.notes.trim())
+    const canSave = Boolean(this.state.selectedTeacherId && this.state.selectedFinalTypeCode && this.state.notes.trim())
 
     return (
       <Dialog open={this.state.alignmentOpen} onClose={this.closeAlignment} fullWidth maxWidth="sm">
@@ -345,11 +374,11 @@ class OpenObservationPage extends React.Component<Props, State> {
           <Button
             color="primary"
             variant="contained"
-            disabled={!canSave}
+            disabled={!canSave || this.state.saving}
             onClick={this.completeObservation}
             data-testid="open-observation-save"
           >
-            Save observation
+            {this.state.saving ? 'Saving...' : 'Save observation'}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary

Adds legacy V1 Open Observation mode without bringing the CHALK 2.0/V2 app into the client repo.

- Adds `/OpenObservation` behind the existing legacy `PrivateRoute` for coach/admin/program/site leader roles.
- Adds a Home card entry for Open Observation.
- Supports teacher selection, provisional Magic 9 type selection, free-form notes, MM:SS timer, and localStorage draft restore.
- Requires final Magic 9 alignment before save; final alignment is the canonical stored type.
- Saves through the existing legacy `Firebase.handleSession()` / `handlePushNotes()` / `endSession()` path.
- Keeps LI Open Observation checklist behavior as `null` via the legacy `handleSession()` normalization; no LI checklist-specific BQ result row is promised.

## Verification

```bash
node scripts/v1-open-observation-type-contract-check.js
node scripts/v1-open-observation-route-check.js
node scripts/v1-open-observation-bq-compat-check.js
npm run staging
```

All passed locally on the clean branch based on `origin/develop`.

## Notes

This PR intentionally keeps the type contract self-contained under V1 components because `develop` does not contain `src/v2/lib/observationTypes.ts`. This avoids delivering the V2 app/code tree as part of a V1-only client requirement.

Cypress spec was added as an acceptance harness, but authenticated Cypress execution still requires a seeded/login-capable test environment.
