### PR TITLE
fix(v1): harden open observation staging load

### DIFF
--- a/scripts/v1-open-observation-route-check.js
+++ b/scripts/v1-open-observation-route-check.js
@@ -21,10 +21,14 @@ const pagePath = 'src/views/protected/OpenObservationViews/OpenObservationPage.t
 const appPath = 'src/App.tsx'
 const homePath = 'src/views/protected/HomeViews/HomePage.tsx'
 const firebasePath = 'src/components/Firebase/Firebase.tsx'
+const reducerPath = 'src/state/reducers/training-literacy-state.ts'
+const webpackPath = 'webpack.config.js'
 const page = exists(pagePath) ? read(pagePath) : ''
 const app = exists(appPath) ? read(appPath) : ''
 const home = exists(homePath) ? read(homePath) : ''
 const firebase = exists(firebasePath) ? read(firebasePath) : ''
+const reducer = exists(reducerPath) ? read(reducerPath) : ''
+const webpack = exists(webpackPath) ? read(webpackPath) : ''
 
 assert(exists(pagePath), 'OpenObservationPage must exist under the legacy protected views tree')
 assert(page.includes('OPEN_OBSERVATION_DRAFT_KEY'), 'Open Observation must use a named localStorage draft key')
@@ -45,6 +49,10 @@ assert(home.includes('/OpenObservation'), 'HomePage must link to /OpenObservatio
 assert(home.includes('Open Observation'), 'HomePage must label the Open Observation entry')
 assert(!home.includes('/v2/'), 'HomePage Open Observation entry must not route through V2')
 assert(firebase.includes('id: doc.id'), 'Firebase.getTeacherInfo must preserve the Firestore doc id for teacher pickers')
+assert(firebase.includes('userRole === "admin"') && firebase.includes("where('role', '==', 'teacher')"), 'Firebase.getTeacherList must let admins load teacher options')
+assert(app.includes('Promise.all') && app.includes('Promise.resolve(teacherEntry)') && app.includes('teacher is Types.Teacher'), 'App.tsx must resolve teacher promises before dispatching getTeacherList')
+assert(reducer.includes('action.literacyTraining || initialState'), 'training literacy reducer must tolerate missing training docs')
+assert(webpack.includes('CopyPublicAssetsPlugin') && webpack.includes('site.webmanifest') && webpack.includes('manifest.json'), 'webpack must copy manifest assets so Firebase hosting does not rewrite them to index.html')
 
 
 if (failures.length > 0) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,14 +215,13 @@ class App extends React.Component<Props, State> {
         this.props.firebase.getLiteracyTraining().then((result: LiteracyTrainingFlags ) => {
           this.props.setLiteracyTraining(result)
         })
-        this.props.firebase.getTeacherList().then((teacherPromiseList: Array<Types.Teacher>) => {
-          const teacherList: Array<Types.Teacher> = [];
-          teacherPromiseList.forEach(tpromise => {
-            tpromise.then((data: Types.Teacher) => {
-              teacherList.push(data);
-            });
-          });
-          this.props.getTeacherList(teacherList);
+        this.props.firebase.getTeacherList().then(async (teacherPromiseList: Array<Promise<Types.Teacher> | Types.Teacher> = []) => {
+          const teacherList = await Promise.all(
+            teacherPromiseList.map((teacherEntry: Promise<Types.Teacher> | Types.Teacher) =>
+              Promise.resolve(teacherEntry).catch(() => null)
+            )
+          );
+          this.props.getTeacherList(teacherList.filter((teacher): teacher is Types.Teacher => Boolean(teacher) && Boolean(teacher.id) && !(teacher as any).archived));
         });
       } else {
         this.setState({

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -449,6 +449,19 @@ class Firebase {
       const userDoc = await this.getUserInformation();
       const userRole = userDoc.role;
 
+      if(userRole === "admin") {
+        const allTeachers = await this.db.collection('users').where('role', '==', 'teacher').get()
+        const teacherList: Array<Promise<firebase.firestore.DocumentData | undefined | void>> = []
+
+        allTeachers.forEach(teacher => {
+          if (teacher.id !== "rJxNhJmzjRZP7xg29Ko6") {
+            teacherList.push(this.getTeacherInfo(teacher.id))
+          }
+        })
+
+        return teacherList
+      }
+
       // Leaders should be getting all teachers that belong to their program/sites. So we need to get their sites first
       if(userRole === "siteLeader" || userRole === "programLeader") {
         let allSiteIds = []

--- a/src/state/reducers/training-literacy-state.ts
+++ b/src/state/reducers/training-literacy-state.ts
@@ -62,7 +62,7 @@ export default (state = initialState, action: TrainingLiteracyTypes): TrainingLi
         knowledgeCheckWriting = false,
         knowledgeCheckReading = false,
         knowledgeCheckLanguage = false
-      } = action.literacyTraining
+      } = action.literacyTraining || initialState
       return {
         ...state,
         conceptsFoundational,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const webpackMerge = require("webpack-merge");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
@@ -5,6 +6,35 @@ const WorkboxPlugin = require('workbox-webpack-plugin');
 const SourceMapPlugin = require('webpack').SourceMapDevToolPlugin;
 const DefinePlugin = require('webpack').DefinePlugin;
 const modeConfiguration = mode => require(`./build-utils/webpack.${mode}`)(mode);
+
+const publicAssets = [
+    "android-chrome-192x192.png",
+    "android-chrome-512x512.png",
+    "apple-touch-icon.png",
+    "browserconfig.xml",
+    "favicon-16x16.png",
+    "favicon-32x32.png",
+    "favicon.ico",
+    "manifest.json",
+    "mstile-150x150.png",
+    "safari-pinned-tab.svg",
+    "site.webmanifest"
+];
+
+class CopyPublicAssetsPlugin {
+    apply(compiler) {
+        compiler.hooks.afterEmit.tap("CopyPublicAssetsPlugin", compilation => {
+            publicAssets.forEach(fileName => {
+                const sourcePath = path.resolve(__dirname, "public", fileName);
+                const outputPath = path.resolve(compilation.outputOptions.path, fileName);
+                if (fs.existsSync(sourcePath)) {
+                    fs.copyFileSync(sourcePath, outputPath);
+                }
+            });
+        });
+    }
+}
+
 module.exports = (env, argv) => {
     console.log(`mode is: ${argv.mode}`);
 
@@ -111,6 +141,7 @@ module.exports = (env, argv) => {
                 new HtmlWebpackPlugin({
                     template: "./public/template/index.html"
                 }),
+                new CopyPublicAssetsPlugin(),
                 new WorkboxPlugin.GenerateSW({
                            // these options encourage the ServiceWorkers to get in there fast
                            // and not allow any straggling "old" SWs to hang around


### PR DESCRIPTION
## Summary
- tolerate missing literacy training docs so App login does not throw on Open Observation
- resolve teacher promises before dispatching Redux teacher list
- let admin users load teacher options for Open Observation
- copy manifest/icon assets into Webpack build so Firebase rewrites do not serve index.html for site.webmanifest

## Verification
- node scripts/v1-open-observation-type-contract-check.js
- node scripts/v1-open-observation-route-check.js
- node scripts/v1-open-observation-bq-compat-check.js
- npm run staging
- JSON parse build/site.webmanifest and build/manifest.json

Closes CHALK-OPEN-OBS-V1
Closes CHALK-2