### PR TITLE
fix(open-observation): limit capture to coach and admin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -340,7 +340,7 @@ class App extends React.Component<Props, State> {
             <PrivateRoute
               auth={auth}
               path="/OpenObservation"
-              allowedRoles={[Role.COACH, Role.ADMIN, Role.PROGRAMLEADER, Role.SITELEADER]}
+              allowedRoles={[Role.COACH, Role.ADMIN]}
               userRole={role}
               render={(props: {
                 history: H.History

--- a/src/components/ToolIcons.tsx
+++ b/src/components/ToolIcons.tsx
@@ -44,6 +44,7 @@ interface Props {
   unlocked?: Array<number>
   history: H.History,
   isTeacher: boolean,
+  role: Role,
   trainingLiteracy: Types.TrainingLiteracy
   practice?: boolean
 }
@@ -62,6 +63,7 @@ function ToolIcons(props: Props): React.ReactElement {
   const [lockedModal, setLockedModal] = useState(false);
   const [literacyTrainingModal, setLiteracyTrainingModal] = useState(false);
   const [openObservationTeacherModal, setOpenObservationTeacherModal] = useState(false);
+  const canCaptureOpenObservation = props.role === Role.COACH || props.role === Role.ADMIN;
 
   // add in other sections later (just tracking knowledge check completion for now)
   const foundationalUnlocked=
@@ -291,7 +293,7 @@ function ToolIcons(props: Props): React.ReactElement {
           </Grid>
         </Grid>
       </>) : (<>
-        {!training && type === 'Observe' && !props.isTeacher ? renderOpenObservationCard() : null}
+        {!training && type === 'Observe' && canCaptureOpenObservation ? renderOpenObservationCard() : null}
         {!training && type === 'Results' ? renderOpenObservationResultsCard() : null}
         <Grid item style={{width: '100%'}}>
           <Grid container direction="row" justify="space-around" alignItems="center" style={{width: '100%', paddingBottom: '1em'}}>
@@ -510,6 +512,7 @@ ToolIcons.propTypes = {
 const mapStateToProps = (state: Types.ReduxState): {
   unlocked: Array<number>,
   isTeacher: boolean,
+  role: Role,
   trainingLiteracy: {
     conceptsFoundational: boolean,
     conceptsWriting: boolean,
@@ -531,6 +534,7 @@ const mapStateToProps = (state: Types.ReduxState): {
 } => {
   return {
     isTeacher: state.coachState.role === Role.TEACHER,
+    role: state.coachState.role,
     unlocked: state.unlockedState.unlocked
         || state.coachState.role === Role.TEACHER,
     trainingLiteracy: state.trainingLiteracyState


### PR DESCRIPTION
## Summary
- Hide the Open Observation capture card for Program Leader / Site Leader roles
- Restrict the /OpenObservation route to Coach and Admin until Bundle B adds PL/SL visibility

## Verification
- npm run lint attempted; repo has pre-existing lint debt unrelated to this change
- NODE_OPTIONS=--openssl-legacy-provider npm run staging
- staging hosting-only deploy: production.3d044a866c86fc123131.js
- NODE_OPTIONS=--openssl-legacy-provider npm run prod
- prod build safety: chalk-dev-c6a5d count = 0, cqrefpwa present
- production hosting-only deploy: production.c5dea27373d0535b6e67.js

Closes CHALK-2